### PR TITLE
Omit the Alembic Migration Files From Analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,4 +10,4 @@ path_classifiers:
     - devtools/*
   generated:
     - nonbonded/_version.py
-    - nonbonded/backend/alembic/versions/*
+    - nonbonded/backend/alembic/*

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,3 +10,4 @@ path_classifiers:
     - devtools/*
   generated:
     - nonbonded/_version.py
+    - nonbonded/backend/alembic/versions/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ omit =
     */tests/*
     # Omit generated versioneer
     nonbonded/_version.py
+    # Omit the alembic migrations
+    nonbonded/backend/alembic/versions/*
 
 [flake8]
 # Flake8, PyFlakes, etc

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ omit =
     # Omit generated versioneer
     nonbonded/_version.py
     # Omit the alembic migrations
-    nonbonded/backend/alembic/versions/*
+    nonbonded/backend/alembic/*
 
 [flake8]
 # Flake8, PyFlakes, etc


### PR DESCRIPTION
## Description
This PR excludes the alembic files from LGTM and codecov analysis as they are automatically generated.

## Status
- [x] Ready to go