### PR TITLE
Allow Benchmarking of Arbitrary Force Fields

### DIFF
--- a/nonbonded/backend/alembic/versions/d4a84f539879_initial_generation.py
+++ b/nonbonded/backend/alembic/versions/d4a84f539879_initial_generation.py
@@ -1,15 +1,15 @@
-"""Initial generation
+"""Initial generation.
 
-Revision ID: d83cb453ffd7
+Revision ID: d4a84f539879
 Revises:
-Create Date: 2020-05-29 13:38:45.287694
+Create Date: 2020-06-08 12:00:47.937419
 
 """
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "d83cb453ffd7"
+revision = "d4a84f539879"
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -46,14 +46,12 @@ def upgrade():
     )
     op.create_index(op.f("ix_data_sets_id"), "data_sets", ["id"], unique=False)
     op.create_table(
-        "initial_force_fields",
+        "force_fields",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("inner_xml", sa.String(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
-        op.f("ix_initial_force_fields_id"), "initial_force_fields", ["id"], unique=False
-    )
+    op.create_index(op.f("ix_force_fields_id"), "force_fields", ["id"], unique=False)
     op.create_table(
         "parameters",
         sa.Column("id", sa.Integer(), nullable=False),
@@ -159,7 +157,6 @@ def upgrade():
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("description", sa.String(), nullable=True),
         sa.Column("optimization_id", sa.Integer(), nullable=True),
-        sa.Column("force_field_name", sa.String(), nullable=True),
         sa.ForeignKeyConstraint(["optimization_id"], ["optimizations.id"],),
         sa.ForeignKeyConstraint(["parent_id"], ["studies.id"],),
         sa.PrimaryKeyConstraint("id"),
@@ -208,12 +205,8 @@ def upgrade():
         "optimization_force_fields",
         sa.Column("optimization_id", sa.Integer(), nullable=False),
         sa.Column("force_field_id", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["force_field_id"], ["initial_force_fields.id"], ondelete="CASCADE"
-        ),
-        sa.ForeignKeyConstraint(
-            ["optimization_id"], ["optimizations.id"], ondelete="CASCADE"
-        ),
+        sa.ForeignKeyConstraint(["force_field_id"], ["force_fields.id"],),
+        sa.ForeignKeyConstraint(["optimization_id"], ["optimizations.id"],),
         sa.PrimaryKeyConstraint("optimization_id", "force_field_id"),
     )
     op.create_table(
@@ -271,6 +264,14 @@ def upgrade():
         sa.PrimaryKeyConstraint("benchmark_id", "environment_id"),
     )
     op.create_table(
+        "benchmark_force_fields",
+        sa.Column("benchmark_id", sa.Integer(), nullable=False),
+        sa.Column("force_field_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["benchmark_id"], ["benchmarks.id"],),
+        sa.ForeignKeyConstraint(["force_field_id"], ["force_fields.id"],),
+        sa.PrimaryKeyConstraint("benchmark_id", "force_field_id"),
+    )
+    op.create_table(
         "benchmark_results",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("parent_id", sa.Integer(), nullable=False),
@@ -324,15 +325,12 @@ def upgrade():
         unique=False,
     )
     op.create_table(
-        "refit_force_fields",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("parent_id", sa.Integer(), nullable=False),
-        sa.Column("inner_xml", sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(["parent_id"], ["optimization_results.id"],),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        op.f("ix_refit_force_fields_id"), "refit_force_fields", ["id"], unique=False
+        "results_force_fields",
+        sa.Column("results_id", sa.Integer(), nullable=False),
+        sa.Column("force_field_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["force_field_id"], ["force_fields.id"],),
+        sa.ForeignKeyConstraint(["results_id"], ["optimization_results.id"],),
+        sa.PrimaryKeyConstraint("results_id", "force_field_id"),
     )
     op.create_table(
         "benchmark_results_entries",
@@ -386,8 +384,7 @@ def downgrade():
         op.f("ix_benchmark_results_entries_id"), table_name="benchmark_results_entries"
     )
     op.drop_table("benchmark_results_entries")
-    op.drop_index(op.f("ix_refit_force_fields_id"), table_name="refit_force_fields")
-    op.drop_table("refit_force_fields")
+    op.drop_table("results_force_fields")
     op.drop_index(
         op.f("ix_optimization_statistics_entries_id"),
         table_name="optimization_statistics_entries",
@@ -398,6 +395,7 @@ def downgrade():
     op.drop_table("benchmark_test_sets")
     op.drop_index(op.f("ix_benchmark_results_id"), table_name="benchmark_results")
     op.drop_table("benchmark_results")
+    op.drop_table("benchmark_force_fields")
     op.drop_table("benchmark_environments")
     op.drop_index(op.f("ix_priors_id"), table_name="priors")
     op.drop_table("priors")
@@ -431,8 +429,8 @@ def downgrade():
     op.drop_table("projects")
     op.drop_index(op.f("ix_parameters_id"), table_name="parameters")
     op.drop_table("parameters")
-    op.drop_index(op.f("ix_initial_force_fields_id"), table_name="initial_force_fields")
-    op.drop_table("initial_force_fields")
+    op.drop_index(op.f("ix_force_fields_id"), table_name="force_fields")
+    op.drop_table("force_fields")
     op.drop_index(op.f("ix_data_sets_id"), table_name="data_sets")
     op.drop_table("data_sets")
     op.drop_index(

--- a/nonbonded/backend/database/crud/forcefield.py
+++ b/nonbonded/backend/database/crud/forcefield.py
@@ -9,3 +9,19 @@ class ParameterCRUD:
     def create(db: Session, parameter: forcefield.Parameter) -> models.Parameter:
         db_parameter = models.Parameter.as_unique(db, **parameter.dict())
         return db_parameter
+
+
+class ForceFieldCRUD:
+    @staticmethod
+    def delete(db: Session, force_field: models.ForceField):
+
+        # Check if the force field still has parents.
+        # noinspection PyUnresolvedReferences
+        if (
+            len(force_field.optimizations) > 0
+            or len(force_field.benchmarks) > 0
+            or len(force_field.results) > 0
+        ):
+            return
+
+        db.delete(force_field)

--- a/nonbonded/backend/database/models/__init__.py
+++ b/nonbonded/backend/database/models/__init__.py
@@ -8,7 +8,7 @@ from .datasets import (  # isort:skip
     DataSetEntry,
 )
 from .forcebalance import ForceBalanceOptions  # isort:skip
-from .forcefield import Parameter  # isort:skip
+from .forcefield import ForceField, Parameter  # isort:skip
 from .results import (  # isort:skip
     BenchmarkResultsEntry,
     BenchmarkStatisticsEntry,
@@ -16,12 +16,10 @@ from .results import (  # isort:skip
     BenchmarkResult,
     ObjectiveFunction,
     OptimizationResult,
-    RefitForceField,
 )
 from .projects import (  # isort:skip
     Benchmark,
     Denominator,
-    InitialForceField,
     Optimization,
     Prior,
     Project,
@@ -41,7 +39,7 @@ __all__ = [
     DataSetEntry,
     Denominator,
     ForceBalanceOptions,
-    InitialForceField,
+    ForceField,
     ObjectiveFunction,
     Optimization,
     OptimizationResult,
@@ -49,7 +47,6 @@ __all__ = [
     Parameter,
     Prior,
     Project,
-    RefitForceField,
     Study,
     UniqueMixin,
 ]

--- a/nonbonded/backend/database/models/forcefield.py
+++ b/nonbonded/backend/database/models/forcefield.py
@@ -25,3 +25,19 @@ class Parameter(UniqueMixin, Base):
             .filter(Parameter.smirks == smirks)
             .filter(Parameter.attribute_name == attribute_name)
         )
+
+
+class ForceField(UniqueMixin, Base):
+
+    __tablename__ = "force_fields"
+
+    id = Column(Integer, primary_key=True, index=True)
+    inner_xml = Column(String)
+
+    @classmethod
+    def unique_hash(cls, inner_xml):
+        return inner_xml
+
+    @classmethod
+    def unique_filter(cls, query: Query, inner_xml):
+        return query.filter(ForceField.inner_xml == inner_xml)

--- a/nonbonded/backend/database/models/results.py
+++ b/nonbonded/backend/database/models/results.py
@@ -1,7 +1,16 @@
-from sqlalchemy import Column, Float, ForeignKey, Integer, String
+from sqlalchemy import Column, Float, ForeignKey, Integer, String, Table
 from sqlalchemy.orm import relationship
 
 from nonbonded.backend.database.models import Base
+
+results_force_field_table = Table(
+    "results_force_fields",
+    Base.metadata,
+    Column(
+        "results_id", Integer, ForeignKey("optimization_results.id"), primary_key=True
+    ),
+    Column("force_field_id", Integer, ForeignKey("force_fields.id"), primary_key=True),
+)
 
 
 class BaseStatisticsEntry(Base):
@@ -73,20 +82,6 @@ class ObjectiveFunction(Base):
     value = Column(Float)
 
 
-class RefitForceField(Base):
-
-    __tablename__ = "refit_force_fields"
-
-    id = Column(Integer, primary_key=True, index=True)
-
-    parent_id = Column(Integer, ForeignKey("optimization_results.id"), nullable=False)
-    parent = relationship(
-        "OptimizationResult", back_populates="refit_force_field", uselist=False
-    )
-
-    inner_xml = Column(String)
-
-
 class OptimizationStatisticsEntry(BaseStatisticsEntry):
 
     __tablename__ = "optimization_statistics_entries"
@@ -112,8 +107,8 @@ class OptimizationResult(Base):
     )
 
     refit_force_field = relationship(
-        "RefitForceField",
-        back_populates="parent",
-        cascade="all, delete-orphan",
+        "ForceField",
+        secondary=results_force_field_table,
+        backref="results",
         uselist=False,
     )

--- a/nonbonded/backend/database/utilities/exceptions.py
+++ b/nonbonded/backend/database/utilities/exceptions.py
@@ -201,3 +201,14 @@ class ProjectNotFoundError(ItemNotFound):
         super(ProjectNotFoundError, self).__init__(
             f"The data base does not contain a project with id={project_id}."
         )
+
+
+class ForceFieldExistsError(ItemExistsError):
+    def __init__(self, project_id, study_id, optimization_id):
+
+        super(ForceFieldExistsError, self).__init__(
+            f"The database already contains the exact same force field "
+            f"as the refit one being uploaded. This should likely never "
+            f"happen (project_id={project_id}, study_id={study_id}, "
+            f"optimization_id={optimization_id})."
+        )

--- a/nonbonded/library/factories/projects/benchmark.py
+++ b/nonbonded/library/factories/projects/benchmark.py
@@ -68,7 +68,6 @@ class BenchmarkFactory:
     ):
 
         from openff.evaluator.client import RequestOptions
-        from openforcefield.typing.engines.smirnoff import ForceField
 
         cls.generate_directory_structure(benchmark)
 
@@ -81,8 +80,8 @@ class BenchmarkFactory:
                 file.write(benchmark.json())
 
             # Retrieve the force field.
-            if benchmark.force_field_name is not None:
-                force_field = ForceField(benchmark.force_field_name)
+            if benchmark.force_field is not None:
+                force_field = benchmark.force_field.to_openff()
             else:
                 optimization_results: OptimizationResult = OptimizationResult.from_rest(
                     project_id=benchmark.project_id,

--- a/nonbonded/library/models/projects.py
+++ b/nonbonded/library/models/projects.py
@@ -149,13 +149,14 @@ class Benchmark(BaseREST):
         ...,
         description="The id of the optimization that should be benchmarked. This must "
         "be the id of an optimization which is part of the same study and project. "
-        "This option is mutually exclusive with `force_field_name`.",
+        "This option is mutually exclusive with `force_field`.",
     )
-    force_field_name: Optional[NonEmptyStr] = Field(
+    force_field: Optional[ForceField] = Field(
         ...,
-        description="The file name of the force field to use in the benchmark. This "
-        "must be the name of a force field in the `openforcefields` GitHub repository. "
-        "This option is mutually exclusive with `optimized_id`.",
+        description="The force field to use in the benchmark. If this is a force field "
+        "produced as part of the same study by one of the optimizations, the "
+        "`optimization_id` input should be used instead of this. This option is "
+        "mutually exclusive with `optimized_id`.",
     )
 
     analysis_environments: List[ChemicalEnvironment] = Field(
@@ -168,12 +169,12 @@ class Benchmark(BaseREST):
     def _validate_mutually_exclusive(cls, values):
 
         optimization_id = values.get("optimization_id")
-        force_field_name = values.get("force_field_name")
+        force_field = values.get("force_field")
 
-        if (optimization_id is None and force_field_name is None) or (
-            optimization_id is not None and force_field_name is not None
+        if (optimization_id is None and force_field is None) or (
+            optimization_id is not None and force_field is not None
         ):
-            raise MutuallyExclusiveError("optimization_id", "force_field_name")
+            raise MutuallyExclusiveError("optimization_id", "force_field")
 
         return values
 

--- a/nonbonded/tests/backend/api/test_projects.py
+++ b/nonbonded/tests/backend/api/test_projects.py
@@ -30,6 +30,7 @@ from nonbonded.tests.backend.crud.utilities.create import (
     create_benchmark,
     create_empty_project,
     create_empty_study,
+    create_force_field,
     create_optimization,
 )
 
@@ -163,7 +164,7 @@ class TestBenchmarkEndpoints(BaseTestEndpoints):
             "benchmark-1",
             data_set_ids,
             None,
-            "openff-1.0.0.offxml",
+            create_force_field(),
         )
 
         return (

--- a/nonbonded/tests/backend/crud/test_projects.py
+++ b/nonbonded/tests/backend/crud/test_projects.py
@@ -1241,7 +1241,7 @@ class TestBenchmarkCRUD:
             "benchmark-1",
             [data_set.id],
             None,
-            create_force_field()
+            create_force_field(),
         )
 
         assert db.query(models.ForceField.id).count() == 0

--- a/nonbonded/tests/backend/crud/test_results.py
+++ b/nonbonded/tests/backend/crud/test_results.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from nonbonded.backend.database import models
-from nonbonded.backend.database.crud.projects import BenchmarkCRUD
+from nonbonded.backend.database.crud.projects import BenchmarkCRUD, OptimizationCRUD
 from nonbonded.backend.database.crud.results import (
     BenchmarkResultCRUD,
     OptimizationResultCRUD,
@@ -14,6 +14,7 @@ from nonbonded.backend.database.utilities.exceptions import (
     BenchmarkResultExistsError,
     BenchmarkResultNotFoundError,
     DataSetEntryNotFound,
+    ForceFieldExistsError,
     OptimizationNotFoundError,
     OptimizationResultExistsError,
     OptimizationResultNotFoundError,
@@ -26,6 +27,7 @@ from nonbonded.tests.backend.crud.utilities.commit import (
     commit_data_set,
     commit_optimization,
     commit_optimization_result,
+    commit_study,
 )
 from nonbonded.tests.backend.crud.utilities.comparison import (
     compare_benchmark_results,
@@ -33,6 +35,8 @@ from nonbonded.tests.backend.crud.utilities.comparison import (
 )
 from nonbonded.tests.backend.crud.utilities.create import (
     create_benchmark_result,
+    create_force_field,
+    create_optimization,
     create_optimization_result,
 )
 
@@ -99,6 +103,29 @@ class TestOptimizationResultCRUD:
             is None
         )
 
+    def test_duplicate_refit_force_field(self, db: Session):
+        """Test that an exception is raised when uploading a refit
+        force field when that force field already is present.
+        """
+
+        data_set = commit_data_set(db)
+        project, study = commit_study(db)
+
+        optimization = create_optimization(
+            project.id, study.id, "optimization-1", [data_set.id]
+        )
+        optimization.initial_force_field = create_force_field("Refit")
+
+        db.add(OptimizationCRUD.create(db, optimization))
+        db.commit()
+
+        result = create_optimization_result(project.id, study.id, optimization.id)
+        result.refit_force_field = create_force_field("Refit")
+
+        # Make sure results with duplicate parents cannot be added.
+        with pytest.raises(ForceFieldExistsError):
+            OptimizationResultCRUD.create(db, result)
+
     def test_delete(self, db: Session):
         """Test that an optimization result can be deleted successfully and also
         that it's children get successfully deleted.
@@ -109,7 +136,7 @@ class TestOptimizationResultCRUD:
         assert db.query(models.OptimizationResult.id).count() == 1
         assert db.query(models.ObjectiveFunction.id).count() == 3
         assert db.query(models.OptimizationStatisticsEntry.id).count() == 3
-        assert db.query(models.RefitForceField.id).count() == 1
+        assert db.query(models.ForceField.id).count() == 2
 
         OptimizationResultCRUD.delete(
             db, results.project_id, results.study_id, results.id
@@ -120,7 +147,11 @@ class TestOptimizationResultCRUD:
         assert db.query(models.OptimizationResult.id).count() == 0
         assert db.query(models.ObjectiveFunction.id).count() == 0
         assert db.query(models.OptimizationStatisticsEntry.id).count() == 0
-        assert db.query(models.RefitForceField.id).count() == 0
+        assert db.query(models.ForceField.id).count() == 1
+
+        # Make sure the right force field as deleted
+        remaining_force_field = db.query(models.ForceField.inner_xml).first()
+        assert "Refit" not in remaining_force_field
 
     def test_delete_not_found(self, db: Session):
 

--- a/nonbonded/tests/backend/crud/utilities/commit.py
+++ b/nonbonded/tests/backend/crud/utilities/commit.py
@@ -17,6 +17,7 @@ from nonbonded.tests.backend.crud.utilities.create import (
     create_data_set,
     create_empty_project,
     create_empty_study,
+    create_force_field,
     create_optimization,
     create_optimization_result,
 )
@@ -177,14 +178,14 @@ def commit_benchmark(
     optimization_id = None
     optimization_result = None
 
-    force_field_name = None
+    force_field = None
 
     if not target_optimization:
 
         data_set = commit_data_set_collection(db)
         data_set_ids = [x.id for x in data_set.data_sets]
 
-        force_field_name = "openff-1.0.0.offxml"
+        force_field = create_force_field()
 
         project, study = commit_study(db)
 
@@ -202,12 +203,7 @@ def commit_benchmark(
         optimization_id = optimization.id
 
     benchmark = create_benchmark(
-        project.id,
-        study.id,
-        "benchmark-1",
-        data_set_ids,
-        optimization_id,
-        force_field_name,
+        project.id, study.id, "benchmark-1", data_set_ids, optimization_id, force_field,
     )
 
     db_benchmark = BenchmarkCRUD.create(db, benchmark)

--- a/nonbonded/tests/backend/crud/utilities/comparison.py
+++ b/nonbonded/tests/backend/crud/utilities/comparison.py
@@ -517,7 +517,11 @@ def compare_benchmarks(
         optimization_id_2 = benchmark_2.optimization_id
 
     assert optimization_id_1 == optimization_id_2
-    assert benchmark_1.force_field_name == benchmark_2.force_field_name
+
+    if benchmark_1.force_field is None:
+        assert benchmark_1.force_field == benchmark_2.force_field
+    else:
+        assert benchmark_1.force_field.inner_xml == benchmark_2.force_field.inner_xml
 
     # Make sure both benchmarks are analyzing the same environments
     assert len(benchmark_1.analysis_environments) == len(

--- a/nonbonded/tests/backend/crud/utilities/create.py
+++ b/nonbonded/tests/backend/crud/utilities/create.py
@@ -21,6 +21,10 @@ from nonbonded.library.statistics.statistics import StatisticType
 from nonbonded.library.utilities.environments import ChemicalEnvironment
 
 
+def create_force_field(inner_text="") -> ForceField:
+    return ForceField(inner_xml=f"<root>{inner_text}</root>")
+
+
 def create_author():
     """Creates an author objects with
 
@@ -128,7 +132,7 @@ def create_optimization(
         name=" ",
         description=" ",
         training_set_ids=data_set_ids,
-        initial_force_field=ForceField(inner_xml="<root/>"),
+        initial_force_field=create_force_field(),
         parameters_to_train=[
             Parameter(handler_type="vdW", smirks="[#6:1]", attribute_name="epsilon")
         ],
@@ -145,7 +149,7 @@ def create_benchmark(
     benchmark_id: str,
     data_set_ids: List[str],
     optimization_id: Optional[str],
-    force_field_name: Optional[str],
+    force_field: Optional[ForceField],
 ) -> Benchmark:
 
     """Creates an benchmark with a specified id which target the specified
@@ -163,12 +167,12 @@ def create_benchmark(
         The ids of the data sets which form the test set.
     optimization_id
         The id of the optimization being benchmarked.
-    force_field_name
-        The name of the OpenFF force field being benchmarked.
+    force_field
+        The force field being benchmarked.
     """
 
-    assert optimization_id is None or force_field_name is None
-    assert optimization_id is not None or force_field_name is not None
+    assert optimization_id is None or force_field is None
+    assert optimization_id is not None or force_field is not None
 
     return Benchmark(
         id=benchmark_id,
@@ -178,7 +182,7 @@ def create_benchmark(
         description=" ",
         test_set_ids=data_set_ids,
         optimization_id=optimization_id,
-        force_field_name=force_field_name,
+        force_field=force_field,
         analysis_environments=[ChemicalEnvironment.Alkane, ChemicalEnvironment.Alcohol],
     )
 
@@ -220,7 +224,7 @@ def create_optimization_result(
             1: [create_statistic_entry()],
             2: [create_statistic_entry()],
         },
-        refit_force_field=ForceField(inner_xml="<root/>"),
+        refit_force_field=create_force_field("Refit"),
     )
 
 

--- a/nonbonded/tests/cli/test_benchmark.py
+++ b/nonbonded/tests/cli/test_benchmark.py
@@ -1,10 +1,15 @@
 import pytest
+from openforcefield.typing.engines.smirnoff.forcefield import (
+    ForceField as SMIRNOFFForceField,
+)
 
 from nonbonded.cli.benchmark import benchmark as benchmark_cli
+from nonbonded.library.models.forcefield import ForceField
 from nonbonded.tests.backend.crud.utilities.create import (
     create_benchmark,
     create_benchmark_result,
     create_data_set,
+    create_force_field,
 )
 from nonbonded.tests.cli.utilities import (
     mock_get_benchmark,
@@ -18,7 +23,12 @@ class TestBenchmarkCLI:
     def test_retrieve(self, requests_mock, runner):
 
         benchmark = create_benchmark(
-            "project-1", "study-1", "benchmark-1", ["data-set-1"], None, "openff-1.0.0"
+            "project-1",
+            "study-1",
+            "benchmark-1",
+            ["data-set-1"],
+            None,
+            create_force_field(),
         )
         mock_get_benchmark(requests_mock, benchmark)
 
@@ -47,7 +57,7 @@ class TestBenchmarkCLI:
             "benchmark-1",
             ["data-set-1"],
             None,
-            "openff-1.0.0.offxml",
+            ForceField.from_openff(SMIRNOFFForceField("openff-1.0.0.offxml")),
         )
         mock_get_benchmark(requests_mock, benchmark)
         mock_get_data_set(requests_mock, create_data_set("data-set-1"))
@@ -77,7 +87,7 @@ class TestBenchmarkCLI:
             "benchmark-1",
             ["data-set-1"],
             None,
-            "openff-1.0.0.offxml",
+            create_force_field(),
         )
         data_set = create_data_set("data-set-1")
         data_set.entries[0].id = 1

--- a/nonbonded/tests/cli/test_project.py
+++ b/nonbonded/tests/cli/test_project.py
@@ -1,6 +1,10 @@
 import pytest
+from openforcefield.typing.engines.smirnoff.forcefield import (
+    ForceField as SMIRNOFFForceField,
+)
 
 from nonbonded.cli.project import project as project_cli
+from nonbonded.library.models.forcefield import ForceField
 from nonbonded.tests.backend.crud.utilities.create import (
     create_benchmark,
     create_data_set,
@@ -41,7 +45,7 @@ class TestProjectCLI:
                 "benchmark-1",
                 ["data-set-1"],
                 None,
-                "openff-1.0.0.offxml",
+                ForceField.from_openff(SMIRNOFFForceField("openff-1.0.0.offxml")),
             )
         ]
 

--- a/nonbonded/tests/cli/test_study.py
+++ b/nonbonded/tests/cli/test_study.py
@@ -1,6 +1,10 @@
 import pytest
+from openforcefield.typing.engines.smirnoff.forcefield import (
+    ForceField as SMIRNOFFForceField,
+)
 
 from nonbonded.cli.study import study as study_cli
+from nonbonded.library.models.forcefield import ForceField
 from nonbonded.tests.backend.crud.utilities.create import (
     create_benchmark,
     create_data_set,
@@ -41,7 +45,7 @@ class TestStudyCLI:
                 "benchmark-1",
                 ["data-set-1"],
                 None,
-                "openff-1.0.0.offxml",
+                ForceField.from_openff(SMIRNOFFForceField("openff-1.0.0.offxml")),
             )
         ]
 

--- a/nonbonded/tests/library/models/test_projects.py
+++ b/nonbonded/tests/library/models/test_projects.py
@@ -41,7 +41,7 @@ def valid_benchmark_kwargs():
         "test_set_ids": [" "],
         "analysis_environments": [],
         "optimization_id": None,
-        "force_field_name": " ",
+        "force_field": ForceField(inner_xml=" "),
     }
 
 
@@ -66,28 +66,26 @@ def test_optimization_validation(valid_optimization_kwargs):
 def test_benchmark_validation(valid_benchmark_kwargs):
     """Test that pydantic correctly validates benchmarks"""
 
+    Benchmark(**{**valid_benchmark_kwargs, "optimization_id": " ", "force_field": None})
     Benchmark(
-        **{**valid_benchmark_kwargs, "optimization_id": " ", "force_field_name": None}
-    )
-    Benchmark(
-        **{**valid_benchmark_kwargs, "optimization_id": None, "force_field_name": " "}
+        **{
+            **valid_benchmark_kwargs,
+            "optimization_id": None,
+            "force_field": ForceField(inner_xml=" "),
+        }
     )
 
     # Test mutually exclusive fields.
     with pytest.raises(ValidationError):
         Benchmark(
-            **{
-                **valid_benchmark_kwargs,
-                "optimization_id": None,
-                "force_field_name": None,
-            }
+            **{**valid_benchmark_kwargs, "optimization_id": None, "force_field": None}
         )
     with pytest.raises(ValidationError):
         Benchmark(
             **{
                 **valid_benchmark_kwargs,
                 "optimization_id": " ",
-                "force_field_name": " ",
+                "force_field": ForceField(inner_xml=" "),
             }
         )
 
@@ -161,7 +159,7 @@ def test_study_validation(valid_optimization_kwargs, valid_benchmark_kwargs):
                     **valid_benchmark_kwargs,
                     "study_id": study_id,
                     "optimization_id": "optim1",
-                    "force_field_name": None,
+                    "force_field": None,
                 }
             )
         ]
@@ -185,7 +183,7 @@ def test_study_validation(valid_optimization_kwargs, valid_benchmark_kwargs):
                         **valid_benchmark_kwargs,
                         "study_id": study_id,
                         "optimization_id": "optim2",
-                        "force_field_name": None,
+                        "force_field": None,
                     }
                 )
             ]


### PR DESCRIPTION
## Description
This PR swaps the `Benchmark.force_field_name` field with a more general `Benchmark.force_field` which accepts `ForceField` objects directly.

This PR further consolidates the several `XXXForceField` database objects into a single one, and adds logic to ensure force fields aren't orphaned in the database.

## Status
- [x] Ready to go