### PR TITLE
Add a New ID Validator Type

### DIFF
--- a/nonbonded/library/models/datasets.py
+++ b/nonbonded/library/models/datasets.py
@@ -6,7 +6,7 @@ from pydantic import Field, conlist
 from nonbonded.library.config import settings
 from nonbonded.library.models import BaseORM, BaseREST
 from nonbonded.library.models.authors import Author
-from nonbonded.library.models.validators.string import NonEmptyStr
+from nonbonded.library.models.validators.string import IdentifierStr, NonEmptyStr
 from nonbonded.library.utilities.exceptions import (
     UnrecognisedPropertyType,
     UnsupportedEndpointError,
@@ -207,7 +207,7 @@ class DataSetEntry(BaseORM):
 
 class DataSet(BaseREST):
 
-    id: str = Field(
+    id: IdentifierStr = Field(
         ..., description="The unique identifier associated with the data set."
     )
 

--- a/nonbonded/library/models/forcebalance.py
+++ b/nonbonded/library/models/forcebalance.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from pydantic import Field
 
 from nonbonded.library.models import BaseORM
-from nonbonded.library.models.validators.string import NonEmptyStr
+from nonbonded.library.models.validators.string import IdentifierStr
 
 if TYPE_CHECKING:
     PositiveFloat = float
@@ -33,6 +33,6 @@ class ForceBalanceOptions(BaseORM):
         "optimizer to be declared converged.",
     )
 
-    target_name: NonEmptyStr = Field(
+    target_name: IdentifierStr = Field(
         "phys-prop", description="The name of the fitting target."
     )

--- a/nonbonded/library/models/projects.py
+++ b/nonbonded/library/models/projects.py
@@ -11,7 +11,7 @@ from nonbonded.library.models.authors import Author
 from nonbonded.library.models.exceptions import MutuallyExclusiveError
 from nonbonded.library.models.forcebalance import ForceBalanceOptions
 from nonbonded.library.models.forcefield import ForceField, Parameter
-from nonbonded.library.models.validators.string import NonEmptyStr
+from nonbonded.library.models.validators.string import IdentifierStr, NonEmptyStr
 from nonbonded.library.utilities.environments import ChemicalEnvironment
 
 if TYPE_CHECKING:
@@ -22,18 +22,18 @@ else:
 
 class Optimization(BaseREST):
 
-    id: NonEmptyStr = Field(
+    id: IdentifierStr = Field(
         ..., description="The unique id assigned to this optimization."
     )
-    study_id: NonEmptyStr = Field(..., description="The id of the parent study.")
-    project_id: NonEmptyStr = Field(..., description="The id of the parent project.")
+    study_id: IdentifierStr = Field(..., description="The id of the parent study.")
+    project_id: IdentifierStr = Field(..., description="The id of the parent project.")
 
     name: NonEmptyStr = Field(..., description="The name of the optimization.")
     description: NonEmptyStr = Field(
         ..., description="A description of this optimization."
     )
 
-    training_set_ids: conlist(NonEmptyStr, min_items=1) = Field(
+    training_set_ids: conlist(IdentifierStr, min_items=1) = Field(
         ...,
         description="The unique identifiers of the data sets to use as part of the "
         "optimization.",
@@ -128,18 +128,18 @@ class Optimization(BaseREST):
 
 class Benchmark(BaseREST):
 
-    id: NonEmptyStr = Field(
+    id: IdentifierStr = Field(
         ..., description="The unique id assigned to this benchmark."
     )
-    study_id: NonEmptyStr = Field(..., description="The id of the parent study.")
-    project_id: NonEmptyStr = Field(..., description="The id of the parent project.")
+    study_id: IdentifierStr = Field(..., description="The id of the parent study.")
+    project_id: IdentifierStr = Field(..., description="The id of the parent project.")
 
     name: NonEmptyStr = Field(..., description="The name of the benchmark.")
     description: NonEmptyStr = Field(
         ..., description="A description of this benchmark."
     )
 
-    test_set_ids: conlist(NonEmptyStr, min_items=1) = Field(
+    test_set_ids: conlist(IdentifierStr, min_items=1) = Field(
         ...,
         description="The unique identifiers of the data sets to use as part of the "
         "benchmarking.",
@@ -238,8 +238,8 @@ class Benchmark(BaseREST):
 
 class Study(BaseREST):
 
-    id: NonEmptyStr = Field(..., description="The unique id assigned to this study.")
-    project_id: NonEmptyStr = Field(..., description="The id of the parent project.")
+    id: IdentifierStr = Field(..., description="The unique id assigned to this study.")
+    project_id: IdentifierStr = Field(..., description="The id of the parent project.")
 
     name: NonEmptyStr = Field(..., description="The name of the study.")
     description: NonEmptyStr = Field(..., description="A description of this study.")
@@ -331,7 +331,7 @@ class StudyCollection(BaseORM):
 
 class Project(BaseREST):
 
-    id: NonEmptyStr = Field(..., description="The unique id assigned to the project.")
+    id: IdentifierStr = Field(..., description="The unique id assigned to the project.")
 
     name: NonEmptyStr = Field(..., description="The name of the project.")
     description: NonEmptyStr = Field(..., description="A description of the project.")

--- a/nonbonded/library/models/results.py
+++ b/nonbonded/library/models/results.py
@@ -14,7 +14,7 @@ from nonbonded.library.models.datasets import (
     DataSetEntry,
 )
 from nonbonded.library.models.forcefield import ForceField
-from nonbonded.library.models.validators.string import NonEmptyStr
+from nonbonded.library.models.validators.string import IdentifierStr, NonEmptyStr
 from nonbonded.library.statistics.statistics import StatisticType, compute_statistics
 from nonbonded.library.utilities.checkmol import analyse_functional_groups
 from nonbonded.library.utilities.environments import ChemicalEnvironment
@@ -372,13 +372,13 @@ class AnalysedResult(BaseORM, abc.ABC):
 
 class BaseResult(BaseREST, abc.ABC):
 
-    project_id: NonEmptyStr = Field(
+    project_id: IdentifierStr = Field(
         ..., description="The id of the project that these results were generated for."
     )
-    study_id: NonEmptyStr = Field(
+    study_id: IdentifierStr = Field(
         ..., description="The id of the study that these results were generated for."
     )
-    id: NonEmptyStr = Field(
+    id: IdentifierStr = Field(
         ...,
         description="The unique id assigned to these results. This should match the id "
         "of the benchmark / optimization which yielded this result.",

--- a/nonbonded/library/models/validators/string.py
+++ b/nonbonded/library/models/validators/string.py
@@ -1,3 +1,6 @@
 from pydantic import constr
 
 NonEmptyStr = constr(min_length=1)
+
+
+IdentifierStr = constr(min_length=1, max_length=32, regex="^[a-z0-9-]*$")

--- a/nonbonded/tests/backend/crud/test_projects.py
+++ b/nonbonded/tests/backend/crud/test_projects.py
@@ -339,8 +339,8 @@ class TestStudyCRUD:
         added and deleted by study updates.
         """
 
-        optimization_data_set = commit_data_set(db, "training_set")
-        benchmark_data_set = commit_data_set(db, "test_set")
+        optimization_data_set = commit_data_set(db, "training-set")
+        benchmark_data_set = commit_data_set(db, "test-set")
 
         project, study = commit_study(db)
 
@@ -468,8 +468,8 @@ class TestStudyCRUD:
         benchmarks works as expected.
         """
 
-        optimization_data_set = commit_data_set(db, "training_set")
-        benchmark_data_set = commit_data_set(db, "test_set")
+        optimization_data_set = commit_data_set(db, "training-set")
+        benchmark_data_set = commit_data_set(db, "test-set")
 
         project, study = commit_study(db)
 
@@ -524,8 +524,8 @@ class TestStudyCRUD:
         benchmarks which have results uploaded raises an exception.
         """
 
-        optimization_data_set = commit_data_set(db, "training_set")
-        benchmark_data_set = commit_data_set(db, "test_set")
+        optimization_data_set = commit_data_set(db, "training-set")
+        benchmark_data_set = commit_data_set(db, "test-set")
 
         project = commit_project(db)
 
@@ -982,7 +982,7 @@ class TestOptimizationCRUD:
 
     def test_update_not_found(self, db: Session):
 
-        optimization = create_optimization(" ", " ", " ", [" "])
+        optimization = create_optimization("a", "b", "c", ["d"])
 
         with pytest.raises(OptimizationNotFoundError):
             OptimizationCRUD.update(db, optimization)
@@ -1423,7 +1423,7 @@ class TestBenchmarkCRUD:
 
     def test_update_not_found(self, db: Session):
 
-        benchmark = create_benchmark(" ", " ", " ", [" "], None, create_force_field())
+        benchmark = create_benchmark("a", "b", "c", ["d"], None, create_force_field())
 
         with pytest.raises(BenchmarkNotFoundError):
             BenchmarkCRUD.update(db, benchmark)

--- a/nonbonded/tests/backend/crud/utilities/commit.py
+++ b/nonbonded/tests/backend/crud/utilities/commit.py
@@ -23,7 +23,7 @@ from nonbonded.tests.backend.crud.utilities.create import (
 )
 
 
-def commit_data_set(db: Session, unique_id: str = "data_set-1") -> DataSet:
+def commit_data_set(db: Session, unique_id: str = "data-set-1") -> DataSet:
     """Creates a new data set and commits it the current session.
 
     Parameters

--- a/nonbonded/tests/cli/test_benchmark.py
+++ b/nonbonded/tests/cli/test_benchmark.py
@@ -121,11 +121,11 @@ class TestBenchmarkCLI:
 
         study = create_empty_study("project-1", "study-1")
         study.optimizations = [
-            create_optimization("project-1", "study-1", "optimization-1", [" "])
+            create_optimization("project-1", "study-1", "optimization-1", ["a"])
         ]
         study.benchmarks = [
             create_benchmark(
-                "project-1", "study-1", "benchmark-1", [" "], "optimization-1", None
+                "project-1", "study-1", "benchmark-1", ["a"], "optimization-1", None
             )
         ]
         mock_get_study(requests_mock, study)

--- a/nonbonded/tests/cli/test_optimization.py
+++ b/nonbonded/tests/cli/test_optimization.py
@@ -115,7 +115,7 @@ class TestOptimizationCLI:
 
         study = create_empty_study("project-1", "study-1")
         study.optimizations = [
-            create_optimization("project-1", "study-1", "optimization-1", [" "])
+            create_optimization("project-1", "study-1", "optimization-1", ["a"])
         ]
         mock_get_study(requests_mock, study)
 

--- a/nonbonded/tests/library/models/test_projects.py
+++ b/nonbonded/tests/library/models/test_projects.py
@@ -19,7 +19,7 @@ def valid_optimization_kwargs():
         "project_id": "id",
         "name": " ",
         "description": " ",
-        "training_set_ids": [" "],
+        "training_set_ids": ["id"],
         "initial_force_field": force_field,
         "parameters_to_train": parameters,
         "force_balance_input": ForceBalanceOptions(),
@@ -38,7 +38,7 @@ def valid_benchmark_kwargs():
         "project_id": "id",
         "name": " ",
         "description": " ",
-        "test_set_ids": [" "],
+        "test_set_ids": ["id"],
         "analysis_environments": [],
         "optimization_id": None,
         "force_field": ForceField(inner_xml=" "),
@@ -98,7 +98,7 @@ def test_study_validation(valid_optimization_kwargs, valid_benchmark_kwargs):
     # Test that a valid study can be produced
     study_kwargs = {
         "id": study_id,
-        "project_id": " ",
+        "project_id": "a",
         "name": " ",
         "description": " ",
     }
@@ -193,13 +193,12 @@ def test_study_validation(valid_optimization_kwargs, valid_benchmark_kwargs):
 def test_project_validation(valid_optimization_kwargs, valid_benchmark_kwargs):
     """Test that pydantic correctly validates studies"""
 
-    project_id = "project1"
-    study_id = "study1"
+    project_id = "project-1"
+    study_id = "study-1"
 
     # Test that a valid project can be produced
     project_kwargs = {
         "id": project_id,
-        "project_id": " ",
         "name": " ",
         "description": " ",
         "authors": [Author(name=" ", email="x@x.com", institute=" ")],
@@ -237,19 +236,19 @@ def test_project_validation(valid_optimization_kwargs, valid_benchmark_kwargs):
         Project(**project_kwargs, studies=[valid_study, valid_study])
 
     # Test bad project id.
-    bad_study = Study(**{**valid_study.dict(), "project_id": " "})
+    bad_study = Study(**{**valid_study.dict(), "project_id": "a"})
 
     with pytest.raises(ValidationError):
         Project(**project_kwargs, studies=[bad_study])
 
     bad_study = Study(**valid_study.dict())
-    bad_study.optimizations[0].project_id = " "
+    bad_study.optimizations[0].project_id = "a"
 
     with pytest.raises(ValidationError):
         Project(**project_kwargs, studies=[bad_study])
 
     bad_study = Study(**valid_study.dict())
-    bad_study.benchmarks[0].project_id = " "
+    bad_study.benchmarks[0].project_id = "a"
 
     with pytest.raises(ValidationError):
         Project(**project_kwargs, studies=[bad_study])

--- a/nonbonded/tests/library/models/test_results.py
+++ b/nonbonded/tests/library/models/test_results.py
@@ -250,9 +250,9 @@ def test_benchmark_result_from_evaluator(estimated_reference_sets):
     estimated_data_set, reference_data_set = estimated_reference_sets
 
     benchmark_result = BenchmarkResult.from_evaluator(
-        project_id=" ",
-        study_id=" ",
-        benchmark_id=" ",
+        project_id="a",
+        study_id="b",
+        benchmark_id="c",
         reference_data_set=reference_data_set,
         estimated_data_set=estimated_data_set,
         analysis_environments=[

--- a/nonbonded/tests/library/models/test_validators.py
+++ b/nonbonded/tests/library/models/test_validators.py
@@ -1,12 +1,17 @@
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from nonbonded.library.models.validators.string import NonEmptyStr
+from nonbonded.library.models.validators.string import IdentifierStr, NonEmptyStr
 
 
 class TestStrClass(BaseModel):
 
     string_field: NonEmptyStr
+
+
+class TestIdStrClass(BaseModel):
+
+    string_field: IdentifierStr
 
 
 def test_none_empty_str():
@@ -17,3 +22,24 @@ def test_none_empty_str():
     # and an empty string is invalid
     with pytest.raises(ValidationError):
         TestStrClass(string_field="")
+
+
+@pytest.mark.parametrize(
+    "valid_string", ["a", "-" "abc-123-cba", "".join(["a"] * 32)],
+)
+def test_valid_identifier_str(valid_string):
+    """Ensures that the identifier string validator works as intended
+    for valid strings."""
+
+    TestIdStrClass(string_field=valid_string)
+
+
+@pytest.mark.parametrize(
+    "invalid_string",
+    ["", "A", "Z", ".", ",", " ", "_", "/", "\\", "".join(["a"] * 33)],
+)
+def test_invalid_identifier_str(invalid_string):
+    """Ensures that the identifier string validator catches invalid strings."""
+
+    with pytest.raises(ValidationError):
+        TestIdStrClass(string_field=invalid_string)

--- a/nonbonded/tests/library/utilities/test_migration.py
+++ b/nonbonded/tests/library/utilities/test_migration.py
@@ -55,7 +55,7 @@ def test_reindex_data_set():
     )
 
     data_set = DataSet(
-        id=" ",
+        id="data-set",
         description=" ",
         authors=[Author(name=" ", email="x@x.com", institute=" ")],
         entries=[


### PR DESCRIPTION
## Description
This PR now strictly validates that an identifier:

* is between 1 and 32 characters long (inclusive).
* contains only lower case letters, arabic numerals or dash symbols.

This will ensure reasonably sized, url and file-path friendly, unique identifiers.

## Status
- [X] Ready to go