### PR TITLE
Fixes Reading Benchmark Results

### DIFF
--- a/nonbonded/backend/database/crud/results.py
+++ b/nonbonded/backend/database/crud/results.py
@@ -120,12 +120,14 @@ class BenchmarkResultCRUD:
 
         db_results_entries = (
             db.query(models.BenchmarkResultsEntry)
-            .filter(models.BenchmarkResultsEntry.parent_id == db_benchmark.id)
+            .filter(models.BenchmarkResultsEntry.parent_id == db_benchmark.results.id)
             .all()
         )
         db_statistic_entries = (
             db.query(models.BenchmarkStatisticsEntry)
-            .filter(models.BenchmarkStatisticsEntry.parent_id == db_benchmark.id)
+            .filter(
+                models.BenchmarkStatisticsEntry.parent_id == db_benchmark.results.id
+            )
             .all()
         )
 


### PR DESCRIPTION
## Description
This PR fixes reading the results of benchmarks when the benchmark results are uploaded in a different order than the benchmarks were. This was caused by the benchmark id, rather than the benchmark result id being queried for.

## Status
- [X] Ready to go