### PR TITLE
Add Finger Print Based Substance Selection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,19 @@ jobs:
     strategy:
 
       matrix:
-        os: [macOS-latest, ubuntu-latest]
         python-version: [3.6, 3.7]
+        cfg:
+          - os: ubuntu-latest
+            openeye: "false"
+
+          - os: macOS-latest
+            openeye: "false"
+
+          - os: ubuntu-latest
+            openeye: "true"
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
     steps:
       - uses: actions/checkout@v2
@@ -37,13 +48,13 @@ jobs:
 
       - name: Install PASCAL Compiler (MacOS)
         shell: bash -l {0}
-        if: startsWith(matrix.os, 'macOS')
+        if: startsWith(matrix.cfg.os, 'macOS')
         run: |
           brew install fpc
 
       - name: Install PASCAL Compiler (Ubuntu)
         shell: bash -l {0}
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.cfg.os, 'ubuntu')
         run: |
           sudo apt-get install fp-compiler
 
@@ -55,6 +66,19 @@ jobs:
           fpc checkmol.pas -S2
 
           echo "::add-path::."
+
+      - name: Install OpenEye toolkit
+        shell: bash -l {0}
+        if: matrix.cfg.openeye
+        run: |
+
+          echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
+          conda install -c openeye openeye-toolkits
+
+          python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
+
+        env:
+          SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
       - name: Install Package
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
 
   test:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.cfg.os }}
 
     strategy:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,13 @@ jobs:
         python-version: [3.6, 3.7]
         cfg:
           - os: ubuntu-latest
-            openeye: "false"
+            openeye: false
 
           - os: macOS-latest
-            openeye: "false"
+            openeye: false
 
           - os: ubuntu-latest
-            openeye: "true"
+            openeye: true
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt

--- a/nonbonded/library/curation/components/selection.py
+++ b/nonbonded/library/curation/components/selection.py
@@ -1,14 +1,40 @@
-from typing import List, Tuple, Union
+import functools
+import itertools
+from enum import Enum
+from typing import TYPE_CHECKING, List, Set, Tuple, Union
 
 import numpy
 import pandas
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, conlist, validator
 from typing_extensions import Literal
 
 from nonbonded.library.curation.components import Component, ComponentSchema
-from nonbonded.library.utilities.pandas import reorder_data_frame
+from nonbonded.library.curation.components.filtering import (
+    FilterByEnvironments,
+    FilterByEnvironmentsSchema,
+    FilterBySubstances,
+    FilterBySubstancesSchema,
+)
+from nonbonded.library.utilities.environments import ChemicalEnvironment
+from nonbonded.library.utilities.exceptions import MissingOptionalDependency
+from nonbonded.library.utilities.pandas import (
+    data_frame_to_substances,
+    reorder_data_frame,
+)
 
 PropertyType = Tuple[str, int]
+
+if TYPE_CHECKING:
+
+    PositiveInt = int
+
+    try:
+        from openeye.oegraphsim import OEFingerPrint
+    except ImportError:
+        OEFingerPrint = None
+
+else:
+    from pydantic import PositiveInt
 
 
 class State(BaseModel):
@@ -39,6 +65,376 @@ class TargetState(BaseModel):
 
         assert all(x[1] == n_components for x in value)
         return value
+
+
+class FingerPrintType(Enum):
+
+    Tree = "Tree"
+    MACCS166 = "MACCS166"
+
+
+class SelectSubstancesSchema(ComponentSchema):
+
+    type: Literal["SelectSubstancesSchema"] = "SelectSubstancesSchema"
+
+    target_environments: conlist(ChemicalEnvironment, min_items=1) = Field(
+        ...,
+        description="The chemical environments which selected substances should "
+        "contain.",
+    )
+
+    n_per_environment: PositiveInt = Field(
+        ...,
+        description="The number of substances to ideally select for each chemical "
+        "environment of interest. In the case of pure substances, this will be the "
+        "number of substances to choose per environment specified in "
+        "`target_environments`. For binary mixtures, this will be the number of "
+        "substances to select for each pair of environments constructed from the "
+        "`target_environments` list and so on.",
+    )
+
+    substances_to_exclude: List[Tuple[str, ...]] = Field(
+        default_factory=list,
+        description="The substances to 1) filter from the available data before "
+        "selecting substances and 2) to penalize similarity to. This field is "
+        "mainly expected to be used when creating a test set which is distinct from "
+        "a training set.",
+    )
+
+    finger_print_type: FingerPrintType = Field(
+        FingerPrintType.Tree,
+        description="The type of finger print to use in the distance metrics.",
+    )
+
+
+class SelectSubstances(Component):
+    @classmethod
+    def _check_oe_available(cls):
+        """Check if the `oechem` and `oegraphsim` modules are available for import.
+
+        Raises
+        -------
+        MissingOptionalDependency
+        """
+        try:
+            from openeye import oechem, oegraphsim
+        except ImportError as e:
+            raise MissingOptionalDependency(e.path, False)
+
+        unlicensed_library = (
+            "openeye.oechem"
+            if not oechem.OEChemIsLicensed()
+            else "openeye.oegraphsim"
+            if not oegraphsim.OEGraphSimIsLicensed()
+            else None
+        )
+
+        if unlicensed_library is not None:
+            raise MissingOptionalDependency(unlicensed_library, True)
+
+    @classmethod
+    @functools.lru_cache(3000)
+    def _compute_molecule_finger_print(
+        cls, smiles: str, finger_print_type: FingerPrintType
+    ) -> "OEFingerPrint":
+        """Computes the finger print for a given molecule
+        using the OpenEye toolkit.
+
+        Parameters
+        ----------
+        smiles
+            The smiles pattern to generate a finger print for.
+        finger_print_type
+            The type of finger print to generate.
+
+        Returns
+        -------
+            The generated finger print.
+        """
+        from openeye.oegraphsim import (
+            OEFingerPrint,
+            OEFPType_Tree,
+            OEFPType_MACCS166,
+            OEMakeFP,
+        )
+        from openforcefield.topology import Molecule
+
+        oe_molecule = Molecule.from_smiles(smiles).to_openeye()
+
+        if finger_print_type == FingerPrintType.Tree:
+            oe_finger_print_type = OEFPType_Tree
+        elif finger_print_type == FingerPrintType.MACCS166:
+            oe_finger_print_type = OEFPType_MACCS166
+        else:
+            raise NotImplementedError()
+
+        finger_print = OEFingerPrint()
+        OEMakeFP(finger_print, oe_molecule, oe_finger_print_type)
+
+        return finger_print
+
+    @classmethod
+    def _compute_mixture_finger_print(
+        cls, mixture: Tuple[str, ...], finger_print_type: FingerPrintType
+    ) -> Tuple["OEFingerPrint", ...]:
+
+        """Computes the finger print of a mixture of molecules as defined
+        by their smiles patterns.
+
+        Parameters
+        ----------
+        mixture
+            The smiles patterns of the molecules in the mixture.
+        finger_print_type
+            The type of finger print to generate.
+
+        Returns
+        -------
+        tuple of OEFingerPrint
+            The finger print of each molecule in the mixture.
+        """
+
+        mixture_finger_print = tuple(
+            cls._compute_molecule_finger_print(x, finger_print_type) for x in mixture
+        )
+
+        return mixture_finger_print
+
+    @classmethod
+    @functools.lru_cache(3000)
+    def _compute_distance(
+        cls,
+        mixture_a: Tuple[str, ...],
+        mixture_b: Tuple[str, ...],
+        finger_print_type: FingerPrintType,
+    ):
+        """Computes the 'distance' between two mixtures based on
+        their finger prints.
+
+        The distance is defined as the minimum of
+
+        - the OETanimoto distance between component a of mixture a and
+          component a of mixture b + the OETanimoto distance between
+          component b of mixture a and component b of mixture b
+
+        and
+
+        - the OETanimoto distance between component b of mixture a and
+          component a of mixture b + the OETanimoto distance between
+          component a of mixture a and component b of mixture b
+
+        Parameters
+        ----------
+        mixture_a
+            The smiles patterns of the molecules in mixture a.
+        mixture_b
+            The smiles patterns of the molecules in mixture b.
+        finger_print_type
+            The type of finger print to base the distance metric
+            on.
+
+        Returns
+        -------
+        float
+            The distance between the mixtures
+        """
+        from openeye.oegraphsim import OETanimoto
+
+        if sorted(mixture_a) == sorted(mixture_b):
+            return 0.0
+
+        finger_print_a = cls._compute_mixture_finger_print(mixture_a, finger_print_type)
+        finger_print_b = cls._compute_mixture_finger_print(mixture_b, finger_print_type)
+
+        if len(mixture_a) == 1 and len(mixture_b) == 1:
+            distance = 1.0 - OETanimoto(finger_print_a[0], finger_print_b[0])
+
+        elif len(mixture_a) == 2 and len(mixture_b) == 2:
+
+            distance = min(
+                (1.0 - OETanimoto(finger_print_a[0], finger_print_b[0]))
+                + (1.0 - OETanimoto(finger_print_a[1], finger_print_b[1])),
+                (1.0 - OETanimoto(finger_print_a[1], finger_print_b[0]))
+                + (1.0 - OETanimoto(finger_print_a[0], finger_print_b[1])),
+            )
+
+        else:
+            raise NotImplementedError()
+
+        return distance
+
+    @classmethod
+    def _compute_distance_with_set(
+        cls,
+        mixture,
+        mixtures: List[Tuple[str, ...]],
+        finger_print_type: FingerPrintType,
+    ) -> float:
+        """Computes the distances between a given mixture and a set of other mixtures.
+
+        This is computed as the sum of `_compute_distance(mixture, mixtures[i])`
+        for all i in `mixtures`.
+
+        Parameters
+        ----------
+        mixture
+            The mixture to compute the distances from.
+        mixtures
+            The set of mixtures to compare with `mixture`.
+        finger_print_type: OEFPTypeBase
+            The type of finger print to base the distance metric
+            on.
+
+        Returns
+        -------
+            The calculated distance.
+        """
+
+        distance = sum(
+            cls._compute_distance(mixture, x, finger_print_type) for x in mixtures
+        )
+
+        return distance
+
+    @classmethod
+    def _select_substances(
+        cls,
+        data_frame: pandas.DataFrame,
+        n_substances: int,
+        previously_chosen: List[Tuple[str, ...]],
+        finger_print_type: FingerPrintType,
+    ) -> List[Tuple[str, ...]]:
+
+        # Store the substances which can be selected, and those which
+        # have already been selected.
+        open_list = [*data_frame_to_substances(data_frame)]
+        closed_list = []
+
+        # Determine the maximum number of substances which can be selected.
+        max_n_possible = min(len(open_list), n_substances)
+
+        while len(open_list) > 0 and len(closed_list) < max_n_possible:
+
+            def distance_metric(mixture):
+
+                return cls._compute_distance_with_set(
+                    mixture, [*previously_chosen, *closed_list], finger_print_type
+                )
+
+            least_similar = sorted(open_list, key=distance_metric, reverse=True)[0]
+
+            open_list.remove(least_similar)
+            closed_list.append(least_similar)
+
+        return closed_list
+
+    @classmethod
+    def _apply(
+        cls, data_frame: pandas.DataFrame, schema: SelectSubstancesSchema, n_processes
+    ) -> pandas.DataFrame:
+        # Make sure OpenEye is available for computing the finger prints.
+        cls._check_oe_available()
+
+        # Filter out any substances which should be excluded
+        filtered_data_frame = FilterBySubstances.apply(
+            data_frame,
+            FilterBySubstancesSchema(
+                substances_to_exclude=schema.substances_to_exclude
+            ),
+            n_processes=n_processes,
+        )
+
+        min_n_components = filtered_data_frame["N Components"].min()
+        max_n_components = filtered_data_frame["N Components"].max()
+
+        if max_n_components > 2:
+            raise NotImplementedError()
+
+        selected_substances = []
+
+        # Perform the selection one for each size of substance (e.g. once
+        # for pure, once for binary etc.)
+        for n_components in range(min_n_components, max_n_components + 1):
+
+            component_data = filtered_data_frame[
+                filtered_data_frame["N Components"] == n_components
+            ]
+
+            if len(component_data) == 1:
+                continue
+
+            # Define all permutations of the target environments.
+            if n_components == 1:
+
+                chemical_environments = [(x,) for x in schema.target_environments]
+
+            elif n_components == 2:
+
+                chemical_environments = [
+                    *[(x, x) for x in schema.target_environments],
+                    *itertools.combinations(schema.target_environments, r=2),
+                ]
+
+            else:
+                raise NotImplementedError()
+
+            # Keep a track of the selected substances
+            selected_n_substances: Set[Tuple[str, ...]] = set()
+
+            for chemical_environment in chemical_environments:
+
+                # Filter out any environments not currently being considered.
+                environment_filter = FilterByEnvironmentsSchema(
+                    per_component_environments={
+                        n_components: [[x] for x in chemical_environment]
+                    }
+                )
+
+                environment_data = FilterByEnvironments.apply(
+                    component_data, environment_filter, n_processes
+                )
+
+                if len(environment_data) == 0:
+                    continue
+
+                # Define the substances which the newly selected substance
+                # should be unique to.
+                substances_to_penalize = {
+                    *selected_n_substances,
+                    *[
+                        x
+                        for x in schema.substances_to_exclude
+                        if len(x) == n_components
+                    ],
+                }
+
+                environment_selected_substances = cls._select_substances(
+                    environment_data,
+                    schema.n_per_environment,
+                    [*substances_to_penalize],
+                    schema.finger_print_type,
+                )
+                selected_n_substances.update(environment_selected_substances)
+
+                # Remove the newly selected substances from the pool to select from.
+                component_data = FilterBySubstances.apply(
+                    component_data,
+                    FilterBySubstancesSchema(
+                        substances_to_exclude=environment_selected_substances
+                    ),
+                    n_processes=n_processes,
+                )
+
+            selected_substances.extend(selected_n_substances)
+
+        # Filter the data frame to retain only the selected substances.
+        data_frame = FilterBySubstances.apply(
+            data_frame,
+            FilterBySubstancesSchema(substances_to_include=selected_substances),
+            n_processes=n_processes,
+        )
+
+        return data_frame
 
 
 class SelectDataPointsSchema(ComponentSchema):
@@ -228,4 +624,4 @@ class SelectDataPoints(Component):
         return selected_data
 
 
-SelectionComponentSchema = Union[SelectDataPointsSchema]
+SelectionComponentSchema = Union[SelectSubstancesSchema, SelectDataPointsSchema]

--- a/nonbonded/library/utilities/exceptions.py
+++ b/nonbonded/library/utilities/exceptions.py
@@ -66,3 +66,39 @@ class InvalidFileObjectError(NonbondedException):
             f"The {file_name} file contained an object of type {found_type} while an "
             f"object of type {expected_type} was expected.."
         )
+
+
+class MissingOptionalDependency(NonbondedException):
+    """An exception raised when an optional dependency is required
+    but cannot be found.
+
+    Attributes
+    ----------
+    library_name
+        The name of the missing library.
+    license_issue
+        Whether the library was importable but was unusable due
+        to a missing license.
+    """
+
+    def __init__(self, library_name: str, license_issue: bool = False):
+        """
+
+        Parameters
+        ----------
+        library_name
+            The name of the missing library.
+        license_issue
+            Whether the library was importable but was unusable due
+            to a missing license.
+        """
+
+        message = f"The required {library_name} module could not be imported."
+
+        if license_issue:
+            message = f"{message} This is due to a missing license."
+
+        super(MissingOptionalDependency, self).__init__(message)
+
+        self.library_name = library_name
+        self.license_issue = license_issue

--- a/nonbonded/library/utilities/pandas.py
+++ b/nonbonded/library/utilities/pandas.py
@@ -1,4 +1,11 @@
-def reorder_data_frame(data_frame):
+from typing import TYPE_CHECKING, Set, Tuple
+
+if TYPE_CHECKING:
+
+    import pandas
+
+
+def reorder_data_frame(data_frame: "pandas.DataFrame") -> "pandas.DataFrame":
     """ Re-order the substance columns of a data frame so that the individual
     components are alphabetically sorted.
 
@@ -66,3 +73,38 @@ def reorder_data_frame(data_frame):
     ordered_data_frame = pandas.concat(ordered_frames, ignore_index=True, sort=False)
 
     return ordered_data_frame
+
+
+def data_frame_to_substances(data_frame: "pandas.DataFrame") -> Set[Tuple[str, ...]]:
+    """Extracts all unique substances from a data frame and returns them
+    as a set, where each element in the set is a tuple of smiles patterns
+    which represent a single substance.
+
+    Parameters
+    ----------
+    data_frame
+        The data frame to extract the substances from.
+
+    Returns
+    -------
+        The set of unique substances.
+    """
+
+    ordered_data = reorder_data_frame(data_frame)
+
+    substances: Set[Tuple[str, ...]] = set()
+
+    min_n_components = data_frame["N Components"].min()
+    max_n_components = data_frame["N Components"].max()
+
+    for n_components in range(min_n_components, max_n_components + 1):
+
+        component_data = ordered_data[ordered_data["N Components"] == n_components]
+
+        component_columns = (
+            component_data[f"Component {i + 1}"] for i in range(n_components)
+        )
+
+        substances.update(list(zip(*component_columns)))
+
+    return substances

--- a/nonbonded/tests/library/curation/test_selection.py
+++ b/nonbonded/tests/library/curation/test_selection.py
@@ -181,8 +181,10 @@ def test_select_substances():
     selected_data_frame = SelectSubstances.apply(data_frame, schema, 1)
 
     assert len(selected_data_frame) == 2
-    assert selected_data_frame.loc[0, "Component 1"] == "CCC(C)C"
-    assert selected_data_frame.loc[0, "Component 2"] == "CCCCCO"
+    assert selected_data_frame["Component 1"].iloc[0] == "CCC(C)C"
+    assert numpy.isnan(selected_data_frame["Component 2"].iloc[0])
+    assert selected_data_frame["Component 1"].iloc[1] == "CCC(C)C"
+    assert selected_data_frame["Component 2"].iloc[1] == "CCCCCO"
 
 
 @pytest.mark.skipif(

--- a/nonbonded/tests/library/curation/test_selection.py
+++ b/nonbonded/tests/library/curation/test_selection.py
@@ -1,15 +1,27 @@
+from typing import Tuple
+
 import numpy
 import pandas
 import pytest
 
 from nonbonded.library.curation.components.selection import (
+    FingerPrintType,
     SelectDataPoints,
     SelectDataPointsSchema,
+    SelectSubstances,
+    SelectSubstancesSchema,
     State,
     TargetState,
 )
 from nonbonded.library.models.authors import Author
 from nonbonded.library.models.datasets import Component, DataSet, DataSetEntry
+from nonbonded.library.utilities.environments import ChemicalEnvironment
+from nonbonded.library.utilities.exceptions import MissingOptionalDependency
+
+try:
+    import openeye.oechem
+except ImportError:
+    openeye = None
 
 
 @pytest.fixture(scope="module")
@@ -93,3 +105,99 @@ def test_select_data_points(target_temperatures, expected_temperatures, data_fra
     expected_temperatures = sorted(expected_temperatures)
 
     assert numpy.allclose(selected_temperatures, expected_temperatures)
+
+
+@pytest.mark.skipif(
+    openeye is None or not openeye.oechem.OEChemIsLicensed(),
+    reason="OpenEye is required for this test.",
+)
+def test_mixture_distance_metric():
+    """Tests that the distance metric between mixtures behaves as
+    expected."""
+
+    assert (
+        SelectSubstances._compute_distance(
+            ("CCCCC", "CCCC=O"), ("CCCC=O", "CCCCC"), FingerPrintType.Tree
+        )
+        == 0.0
+    )
+    assert (
+        SelectSubstances._compute_distance(
+            ("CCCCC", "CCCC=O"), ("C#N", "CCCCC"), FingerPrintType.Tree
+        )
+        == 1.0
+    )
+
+
+@pytest.mark.parametrize(
+    "mixture_a", [("Oc1occc1", "c1ccncc1"), ("c1ccncc1", "Oc1occc1")]
+)
+@pytest.mark.parametrize("mixture_b", [("CCCC=O", "CC(C)C#N"), ("CC(C)C#N", "CCCC=O")])
+@pytest.mark.skipif(
+    openeye is None or not openeye.oechem.OEChemIsLicensed(),
+    reason="OpenEye is required for this test.",
+)
+def test_mixture_distance_metric_symmetry(
+    mixture_a: Tuple[str, str], mixture_b: Tuple[str, str]
+):
+    """Tests that the distance metric between mixtures behaves as
+    expected and symmetrically under permutation"""
+
+    distance_a_b = SelectSubstances._compute_distance(
+        mixture_a, mixture_b, FingerPrintType.Tree
+    )
+    distance_b_a = SelectSubstances._compute_distance(
+        mixture_b, mixture_a, FingerPrintType.Tree
+    )
+
+    assert numpy.isclose(distance_a_b, distance_b_a)
+
+
+@pytest.mark.skipif(
+    openeye is None or not openeye.oechem.OEChemIsLicensed(),
+    reason="OpenEye is required for this test.",
+)
+def test_select_substances():
+
+    training_substances = [("CCCCC",), ("CCCCC", "CCCCCO")]
+
+    data_rows = [
+        {"N Components": 1, "Component 1": "CCCCC"},
+        {"N Components": 1, "Component 1": "CCCCCC"},
+        {"N Components": 1, "Component 1": "CCC(C)C"},
+        {"N Components": 2, "Component 1": "CCCCC", "Component 2": "CCCCCO"},
+        {"N Components": 2, "Component 1": "CCCCCC", "Component 2": "CCCCCCO"},
+        {"N Components": 2, "Component 1": "CCC(C)C", "Component 2": "CCCCCO"},
+    ]
+
+    data_frame = pandas.DataFrame(data_rows)
+
+    schema = SelectSubstancesSchema(
+        target_environments=[ChemicalEnvironment.Alkane, ChemicalEnvironment.Alcohol],
+        n_per_environment=1,
+        substances_to_exclude=training_substances,
+    )
+
+    selected_data_frame = SelectSubstances.apply(data_frame, schema, 1)
+
+    assert len(selected_data_frame) == 2
+    assert selected_data_frame.loc[0, "Component 1"] == "CCC(C)C"
+    assert selected_data_frame.loc[0, "Component 2"] == "CCCCCO"
+
+
+@pytest.mark.skipif(
+    openeye is not None and openeye.oechem.OEChemIsLicensed(),
+    reason="OpenEye should not be installed for this test.",
+)
+def test_missing_openeye_dependency():
+
+    data_frame = pandas.DataFrame([{"N Components": 1, "Component 1": "CCCCC"}])
+
+    with pytest.raises(MissingOptionalDependency):
+
+        SelectSubstances.apply(
+            data_frame,
+            SelectSubstancesSchema(
+                target_environments=[ChemicalEnvironment.Alkane], n_per_environment=1
+            ),
+        )

--- a/nonbonded/tests/library/utilities/test_pandas.py
+++ b/nonbonded/tests/library/utilities/test_pandas.py
@@ -1,6 +1,9 @@
 import pandas
 
-from nonbonded.library.utilities.pandas import reorder_data_frame
+from nonbonded.library.utilities.pandas import (
+    data_frame_to_substances,
+    reorder_data_frame,
+)
 
 
 def test_reorder_data_frame():
@@ -57,3 +60,20 @@ def test_reorder_data_frame():
         assert reordered_data_frame.loc[index, "Role 2"] == "Solute"
         assert reordered_data_frame.loc[index, "Mole Fraction 2"] == 0.75
         assert reordered_data_frame.loc[index, "Exact Amount 2"] == 2
+
+
+def test_data_frame_to_substances():
+    """Tests that the ``data_frame_to_substances`` function behaves as expected
+    for 1 and 2 component entries, especially when identical substances but
+    with different ordering are present."""
+
+    data_rows = [
+        {"N Components": 1, "Component 1": "C"},
+        {"N Components": 2, "Component 1": "CC", "Component 2": "CO"},
+        {"N Components": 2, "Component 1": "CO", "Component 2": "CC"},
+    ]
+
+    data_frame = pandas.DataFrame(data_rows)
+
+    substances = data_frame_to_substances(data_frame)
+    assert substances == {("C",), ("CC", "CO")}


### PR DESCRIPTION
## Description
This PR adds a new selection component which attempts to select a diverse set of substances from a data set covering a range of different chemical environments.

The component primarily defines a distance metric between two mixtures based on a finger print (a tree finger print by default), and then greedily attempts to select molecules which are maximally distant based on this metric.

The finger prints and distances between them are currently computed using the OpenEye toolkit, and so for now the CI has been updated to optionally include this as a dependency.

## Status
- [X] Ready to go