### PR TITLE
Adds Strict Filtering of Property Types

### DIFF
--- a/nonbonded/library/utilities/pandas.py
+++ b/nonbonded/library/utilities/pandas.py
@@ -90,6 +90,9 @@ def data_frame_to_substances(data_frame: "pandas.DataFrame") -> Set[Tuple[str, .
         The set of unique substances.
     """
 
+    if len(data_frame) == 0:
+        return set()
+
     ordered_data = reorder_data_frame(data_frame)
 
     substances: Set[Tuple[str, ...]] = set()


### PR DESCRIPTION
## Description
This PR adds a `strict` mode to the `FilterByPropertyTypes` filter. This retains only measurements made for substances which have data for all of the specified property types. This does not take things such as the substance concentration, or the state at which the data was measured into consideration.

This enable asking questions such as - which substances have measurements for both enthalpy of mixing and mass density.

## Status
- [X] Ready to go