### PR TITLE
Exclude Coverage of TYPE_CHECKING Blocks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,11 @@ omit =
     # Omit the alembic migrations
     nonbonded/backend/alembic/*
 
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 88


### PR DESCRIPTION
## Description
This PR configures codecov to ignore TYPE_CHECKING blocks which are never run but are still counted as needing test coverage.

## Status
- [X] Ready to go