### PR TITLE
Expose Extra Optimisation Options for ForceBalance and Evaluator

### DIFF
--- a/nonbonded/backend/alembic/versions/76f4d5475fb1_evaluator_opt_options.py
+++ b/nonbonded/backend/alembic/versions/76f4d5475fb1_evaluator_opt_options.py
@@ -1,0 +1,68 @@
+"""Expose default evaluator options for forcebalance.
+
+Revision ID: 76f4d5475fb1
+Revises: d4a84f539879
+Create Date: 2020-06-18 15:40:34.583401
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "76f4d5475fb1"
+down_revision = "d4a84f539879"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    op.alter_column(
+        "forcebalance",
+        column_name="target_name",
+        new_column_name="evaluator_target_name",
+    )
+
+    op.add_column(
+        "forcebalance", sa.Column("allow_reweighting", sa.Boolean(), nullable=True)
+    )
+    op.add_column(
+        "forcebalance", sa.Column("n_effective_samples", sa.Integer(), nullable=True)
+    )
+
+    op.add_column(
+        "forcebalance",
+        sa.Column("allow_direct_simulation", sa.Boolean(), nullable=True),
+    )
+    op.add_column("forcebalance", sa.Column("n_molecules", sa.Integer(), nullable=True))
+
+    op.add_column(
+        "forcebalance", sa.Column("initial_trust_radius", sa.Float(), nullable=True)
+    )
+    op.add_column(
+        "forcebalance", sa.Column("minimum_trust_radius", sa.Float(), nullable=True)
+    )
+
+    op.execute("UPDATE forcebalance SET allow_reweighting = false")
+    op.execute("UPDATE forcebalance SET allow_direct_simulation = true")
+
+    op.execute("UPDATE forcebalance SET initial_trust_radius = 0.25")
+    op.execute("UPDATE forcebalance SET minimum_trust_radius = 0.05")
+
+
+def downgrade():
+
+    op.drop_column("forcebalance", "minimum_trust_radius")
+    op.drop_column("forcebalance", "initial_trust_radius")
+
+    op.drop_column("forcebalance", "n_molecules")
+    op.drop_column("forcebalance", "allow_direct_simulation")
+
+    op.drop_column("forcebalance", "n_effective_samples")
+    op.drop_column("forcebalance", "allow_reweighting")
+
+    op.alter_column(
+        "forcebalance",
+        column_name="evaluator_target_name",
+        new_column_name="target_name",
+    )

--- a/nonbonded/backend/database/models/forcebalance.py
+++ b/nonbonded/backend/database/models/forcebalance.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Float, ForeignKey, Integer, String
+from sqlalchemy import Boolean, Column, Float, ForeignKey, Integer, String
 
 from nonbonded.backend.database.models import Base
 
@@ -18,4 +18,13 @@ class ForceBalanceOptions(Base):
 
     n_criteria = Column(Integer)
 
-    target_name = Column(String)
+    initial_trust_radius = Column(Float)
+    minimum_trust_radius = Column(Float)
+
+    evaluator_target_name = Column(String)
+
+    allow_direct_simulation = Column(Boolean)
+    n_molecules = Column(Integer)
+
+    allow_reweighting = Column(Boolean)
+    n_effective_samples = Column(Integer)

--- a/nonbonded/cli/optimization/analyze.py
+++ b/nonbonded/cli/optimization/analyze.py
@@ -76,14 +76,14 @@ def analyze(reindex, log_level):
     reference_data_sets = DataSetCollection.parse_file(
         os.path.join(
             "targets",
-            optimization.force_balance_input.target_name,
+            optimization.force_balance_input.evaluator_target_name,
             "training-set-collection.json",
         )
     )
 
     # Determine the number of optimization iterations.
     tmp_directory = os.path.join(
-        "optimize.tmp", optimization.force_balance_input.target_name
+        "optimize.tmp", optimization.force_balance_input.evaluator_target_name
     )
 
     n_iterations = len(glob(os.path.join(tmp_directory, "iter_*", "results.json")))

--- a/nonbonded/cli/optimization/run.py
+++ b/nonbonded/cli/optimization/run.py
@@ -83,7 +83,7 @@ def run(server_config, restart: bool, log_level):
 
     else:
 
-        target_name = optimization.force_balance_input.target_name
+        target_name = optimization.force_balance_input.evaluator_target_name
 
         previous_iteration_directories = glob(
             os.path.join("optimize.tmp", target_name, "iter_*")

--- a/nonbonded/data/jinja/optimize.txt
+++ b/nonbonded/data/jinja/optimize.txt
@@ -41,8 +41,8 @@ finite_difference_h 0.001
 # (float) Factor for multiplicative penalty function in objective function
 penalty_additive 1.0
 
-trust0 0.25
-mintrust 0.05
+trust0 {{initial_trust_radius}}
+mintrust {{minimum_trust_radius}}
 error_tolerance 1.0
 adaptive_factor 0.2
 adaptive_damping 1.0
@@ -61,7 +61,7 @@ priors
 $end
 
 $target
-name {{target_name}}
+name {{evaluator_target_name}}
 type Evaluator_SMIRNOFF
 weight 1.0
 evaluator_input options.json

--- a/nonbonded/library/models/forcebalance.py
+++ b/nonbonded/library/models/forcebalance.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
+from pydantic import Field, root_validator
 
 from nonbonded.library.models import BaseORM
 from nonbonded.library.models.validators.string import IdentifierStr
@@ -33,6 +33,54 @@ class ForceBalanceOptions(BaseORM):
         "optimizer to be declared converged.",
     )
 
-    target_name: IdentifierStr = Field(
-        "phys-prop", description="The name of the fitting target."
+    initial_trust_radius: PositiveFloat = Field(
+        0.25, description="The initial trust radius."
     )
+    minimum_trust_radius: PositiveFloat = Field(
+        0.05, description="The minimum trust radius."
+    )
+
+    evaluator_target_name: IdentifierStr = Field(
+        "phys-prop", description="The name of the evaluator fitting target."
+    )
+
+    allow_direct_simulation: bool = Field(
+        True,
+        description="This option controls whether the OpenFF Evaluator should be "
+        "allowed to attempt to estimate the physical property training set using the "
+        "direct simulation calculation layer.",
+    )
+    n_molecules: Optional[PositiveInt] = Field(
+        None,
+        description="This field controls the number of molecules to use in the "
+        "simulations of physical properties. This value is only used when simulating "
+        "properties whose default simulation schema (see the OpenFF Evaluator "
+        "documentation for details) accept this option. If no value is provided the "
+        "schema default will be used.",
+    )
+
+    allow_reweighting: bool = Field(
+        False,
+        description="This option controls whether the OpenFF Evaluator should be "
+        "allowed to attempt to estimate the physical property training set using the "
+        "cached simulation data reweighting calculation layer.",
+    )
+    n_effective_samples: Optional[PositiveInt] = Field(
+        None,
+        description="This field controls the minimum number of effective samples which "
+        "are required in order to estimate a physical property be reweighting cached "
+        "simulation data. This value is only used when reweighting properties whose "
+        "default reweighting schema (see the OpenFF Evaluator documentation for "
+        "details) accept this option. If no value is provided the schema default will "
+        "be used.",
+    )
+
+    @root_validator
+    def _validate_calculation_layers(cls, values):
+        """Validates that at least one calculation approach has been specified."""
+        allow_direct_simulation = values.get("allow_direct_simulation")
+        allow_reweighting = values.get("allow_reweighting")
+
+        assert allow_direct_simulation or allow_reweighting
+
+        return values

--- a/nonbonded/library/templates/forcebalance.py
+++ b/nonbonded/library/templates/forcebalance.py
@@ -17,7 +17,9 @@ class ForceBalanceInput(BaseTemplate):
         convergence_objective_criteria: float,
         convergence_gradient_criteria: float,
         n_criteria: int,
-        target_name: str,
+        initial_trust_radius: float,
+        minimum_trust_radius: float,
+        evaluator_target_name: str,
         priors: Dict[str, float],
         **options
     ):
@@ -36,7 +38,9 @@ class ForceBalanceInput(BaseTemplate):
             convergence_objective_criteria=convergence_objective_criteria,
             convergence_gradient_criteria=convergence_gradient_criteria,
             n_criteria=n_criteria,
-            target_name=target_name,
+            initial_trust_radius=initial_trust_radius,
+            minimum_trust_radius=minimum_trust_radius,
+            evaluator_target_name=evaluator_target_name,
             priors=priors,
         )
         return rendered_template

--- a/nonbonded/tests/backend/crud/utilities/comparison.py
+++ b/nonbonded/tests/backend/crud/utilities/comparison.py
@@ -304,9 +304,33 @@ def compare_optimizations(
         optimization_1.force_balance_input.n_criteria
         == optimization_2.force_balance_input.n_criteria
     )
+    assert numpy.isclose(
+        optimization_1.force_balance_input.initial_trust_radius,
+        optimization_2.force_balance_input.initial_trust_radius,
+    )
+    assert numpy.isclose(
+        optimization_1.force_balance_input.minimum_trust_radius,
+        optimization_2.force_balance_input.minimum_trust_radius,
+    )
     assert (
-        optimization_1.force_balance_input.target_name
-        == optimization_2.force_balance_input.target_name
+        optimization_1.force_balance_input.evaluator_target_name
+        == optimization_2.force_balance_input.evaluator_target_name
+    )
+    assert (
+        optimization_1.force_balance_input.allow_direct_simulation
+        == optimization_2.force_balance_input.allow_direct_simulation
+    )
+    assert (
+        optimization_1.force_balance_input.n_molecules
+        == optimization_2.force_balance_input.n_molecules
+    )
+    assert (
+        optimization_1.force_balance_input.allow_reweighting
+        == optimization_2.force_balance_input.allow_reweighting
+    )
+    assert (
+        optimization_1.force_balance_input.n_effective_samples
+        == optimization_2.force_balance_input.n_effective_samples
     )
 
     # Make sure the same denominators are being used.

--- a/nonbonded/tests/cli/test_optimization.py
+++ b/nonbonded/tests/cli/test_optimization.py
@@ -2,7 +2,6 @@ import os
 import sys
 
 import pytest
-from forcebalance.evaluator_io import Evaluator_SMIRNOFF
 
 from nonbonded.cli.optimization import optimization as optimization_cli
 from nonbonded.library.models.forcefield import ForceField
@@ -53,6 +52,7 @@ class TestOptimizationCLI:
     )
     def test_generate(self, requests_mock, runner):
 
+        from forcebalance.evaluator_io import Evaluator_SMIRNOFF
         from openforcefield.typing.engines.smirnoff.forcefield import (
             ForceField as SMIRNOFFForceField,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ known_third_party=
     click
     cmiles
     fastapi
+    forcebalance
     jinja2
     mock
     numpy


### PR DESCRIPTION
## Description
This PR exposes a number of additional options for both ForceBalance and it's interface with the OpenFF Evaluator. In particular:

- the minimum and initial ForceBalance trust radius
- the number of molecules to include in simulations (where settable)
- the minimum number of effective samples for reweighting (where settable)

are now all exposed as options. Additionally, options to toggle whether to enable reweighting (or disable simulations) in now included.

## Status
- [x] Ready to go