### PR TITLE
Fix Reindex Warning in Temperature and Pressure Filters

### DIFF
--- a/nonbonded/library/curation/components/filtering.py
+++ b/nonbonded/library/curation/components/filtering.py
@@ -172,12 +172,12 @@ class FilterByTemperature(Component):
 
         if schema.minimum_temperature is not None:
             filtered_frame = filtered_frame[
-                schema.minimum_temperature < data_frame["Temperature (K)"]
+                schema.minimum_temperature < filtered_frame["Temperature (K)"]
             ]
 
         if schema.maximum_temperature is not None:
             filtered_frame = filtered_frame[
-                data_frame["Temperature (K)"] < schema.maximum_temperature
+                filtered_frame["Temperature (K)"] < schema.maximum_temperature
             ]
 
         return filtered_frame
@@ -217,12 +217,12 @@ class FilterByPressure(Component):
 
         if schema.minimum_pressure is not None:
             filtered_frame = filtered_frame[
-                schema.minimum_pressure < data_frame["Pressure (kPa)"]
+                schema.minimum_pressure < filtered_frame["Pressure (kPa)"]
             ]
 
         if schema.maximum_pressure is not None:
             filtered_frame = filtered_frame[
-                data_frame["Pressure (kPa)"] < schema.maximum_pressure
+                filtered_frame["Pressure (kPa)"] < schema.maximum_pressure
             ]
 
         return filtered_frame


### PR DESCRIPTION
## Description
This PR fixes a warning which was raised when applying the temperature and pressure filters due to the filter being applied to the initial, rather than the currently filtered, data frame.

## Status
- [X] Ready to go