### PR TITLE
Generalise the Force Field Content Field

### DIFF
--- a/nonbonded/backend/alembic/versions/cc2f9c6b253b_generalize_ff_content.py
+++ b/nonbonded/backend/alembic/versions/cc2f9c6b253b_generalize_ff_content.py
@@ -1,0 +1,28 @@
+"""Generalize FF content
+
+Revision ID: cc2f9c6b253b
+Revises: 76f4d5475fb1
+Create Date: 2020-06-21 08:38:31.933039
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "cc2f9c6b253b"
+down_revision = "76f4d5475fb1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    op.alter_column(
+        "force_fields", column_name="inner_xml", new_column_name="inner_content",
+    )
+
+
+def downgrade():
+
+    op.alter_column(
+        "force_fields", column_name="inner_content", new_column_name="inner_xml",
+    )

--- a/nonbonded/backend/database/crud/projects.py
+++ b/nonbonded/backend/database/crud/projects.py
@@ -94,7 +94,7 @@ class OptimizationCRUD:
                 **optimization.force_balance_input.dict()
             ),
             initial_force_field=models.ForceField.as_unique(
-                db, inner_xml=optimization.initial_force_field.inner_xml
+                db, inner_content=optimization.initial_force_field.inner_content
             ),
             denominators=[
                 models.Denominator(property_type=key, value=value)
@@ -195,12 +195,12 @@ class OptimizationCRUD:
         original_initial_force_field = db_optimization.initial_force_field
 
         db_optimization.initial_force_field = models.ForceField.as_unique(
-            db, inner_xml=optimization.initial_force_field.inner_xml
+            db, inner_content=optimization.initial_force_field.inner_content
         )
 
         if (
-            original_initial_force_field.inner_xml
-            != optimization.initial_force_field.inner_xml
+            original_initial_force_field.inner_content
+            != optimization.initial_force_field.inner_content
         ):
             # Attempt to delete the initial FF if it might now be an orphan.
             ForceFieldCRUD.delete(db, original_initial_force_field)
@@ -384,7 +384,7 @@ class BenchmarkCRUD:
             force_field=None
             if benchmark.force_field is None
             else models.ForceField.as_unique(
-                db, inner_xml=benchmark.force_field.inner_xml
+                db, inner_content=benchmark.force_field.inner_content
             ),
             analysis_environments=[
                 models.ChemicalEnvironment.as_unique(db, id=x.value)
@@ -461,14 +461,15 @@ class BenchmarkCRUD:
             None
             if benchmark.force_field is None
             else models.ForceField.as_unique(
-                db, inner_xml=benchmark.force_field.inner_xml
+                db, inner_content=benchmark.force_field.inner_content
             )
         )
 
         if (benchmark.force_field is None and original_force_field is not None) or (
             benchmark.force_field is not None
             and original_force_field is not None
-            and original_force_field.inner_xml != benchmark.force_field.inner_xml
+            and original_force_field.inner_content
+            != benchmark.force_field.inner_content
         ):
             # Attempt to delete the FF if it might now be an orphan.
             ForceFieldCRUD.delete(db, original_force_field)

--- a/nonbonded/backend/database/crud/results.py
+++ b/nonbonded/backend/database/crud/results.py
@@ -227,10 +227,10 @@ class OptimizationResultCRUD:
             )
 
         if (
-            db.query(models.ForceField.inner_xml)
+            db.query(models.ForceField.inner_content)
             .filter(
-                models.ForceField.inner_xml
-                == optimization_result.refit_force_field.inner_xml
+                models.ForceField.inner_content
+                == optimization_result.refit_force_field.inner_content
             )
             .count()
             > 0
@@ -252,7 +252,7 @@ class OptimizationResultCRUD:
                 for i, x in optimization_result.objective_function.items()
             ],
             refit_force_field=models.ForceField.as_unique(
-                db, inner_xml=optimization_result.refit_force_field.inner_xml
+                db, inner_content=optimization_result.refit_force_field.inner_content
             ),
             statistics=[
                 models.OptimizationStatisticsEntry(

--- a/nonbonded/backend/database/models/forcefield.py
+++ b/nonbonded/backend/database/models/forcefield.py
@@ -32,12 +32,12 @@ class ForceField(UniqueMixin, Base):
     __tablename__ = "force_fields"
 
     id = Column(Integer, primary_key=True, index=True)
-    inner_xml = Column(String)
+    inner_content = Column(String)
 
     @classmethod
-    def unique_hash(cls, inner_xml):
-        return inner_xml
+    def unique_hash(cls, inner_content):
+        return inner_content
 
     @classmethod
-    def unique_filter(cls, query: Query, inner_xml):
-        return query.filter(ForceField.inner_xml == inner_xml)
+    def unique_filter(cls, query: Query, inner_content):
+        return query.filter(ForceField.inner_content == inner_content)

--- a/nonbonded/library/models/forcefield.py
+++ b/nonbonded/library/models/forcefield.py
@@ -30,7 +30,7 @@ class Parameter(BaseORM):
 
 class ForceField(BaseORM):
 
-    inner_xml: NonEmptyStr = Field(
+    inner_content: NonEmptyStr = Field(
         ...,
         description="The xml representation of a force field in the SMIRNOFF "
         "force field format",
@@ -40,14 +40,14 @@ class ForceField(BaseORM):
     def from_openff(cls, force_field: "OpenForceField") -> "ForceField":
 
         return ForceField(
-            inner_xml=force_field.to_string(discard_cosmetic_attributes=True)
+            inner_content=force_field.to_string(discard_cosmetic_attributes=True)
         )
 
     def to_openff(self) -> "OpenForceField":
 
         from openforcefield.typing.engines.smirnoff.forcefield import ForceField
 
-        force_field = ForceField(self.inner_xml)
+        force_field = ForceField(self.inner_content)
 
         return force_field
 

--- a/nonbonded/library/models/forcefield.py
+++ b/nonbonded/library/models/forcefield.py
@@ -32,8 +32,9 @@ class ForceField(BaseORM):
 
     inner_content: NonEmptyStr = Field(
         ...,
-        description="The xml representation of a force field in the SMIRNOFF "
-        "force field format",
+        description="The string representation of a set of force field parameters."
+        "This should either be an OpenFF SMIRNOFF representation, or an "
+        "OpenFF Evaluator JSON serialized `ForceFieldSource`.",
     )
 
     @classmethod

--- a/nonbonded/tests/backend/api/test_results.py
+++ b/nonbonded/tests/backend/api/test_results.py
@@ -55,7 +55,7 @@ class TestOptimizationResultEndpoints(BaseTestEndpoints):
 
     @classmethod
     def _perturb_model(cls, model):
-        model.refit_force_field.inner_xml = "<root>Updated</root>"
+        model.refit_force_field.inner_content = "<root>Updated</root>"
 
     @classmethod
     def _commit_model(cls, db):

--- a/nonbonded/tests/backend/crud/test_projects.py
+++ b/nonbonded/tests/backend/crud/test_projects.py
@@ -877,8 +877,8 @@ class TestOptimizationCRUD:
 
         updated_optimization.initial_force_field = create_force_field("Updated")
         assert (
-            updated_optimization.initial_force_field.inner_xml
-            not in db.query(models.ForceField.inner_xml).first()[0]
+            updated_optimization.initial_force_field.inner_content
+            not in db.query(models.ForceField.inner_content).first()[0]
         )
 
         update_and_compare_model(
@@ -891,8 +891,8 @@ class TestOptimizationCRUD:
 
         assert db.query(models.ForceField.id).count() == 1
         assert (
-            db.query(models.ForceField.inner_xml).first()[0]
-            == updated_optimization.initial_force_field.inner_xml
+            db.query(models.ForceField.inner_content).first()[0]
+            == updated_optimization.initial_force_field.inner_content
         )
 
     def test_update_missing_data_set(self, db: Session):

--- a/nonbonded/tests/backend/crud/test_results.py
+++ b/nonbonded/tests/backend/crud/test_results.py
@@ -151,7 +151,7 @@ class TestOptimizationResultCRUD:
         assert db.query(models.ForceField.id).count() == 1
 
         # Make sure the right force field as deleted
-        remaining_force_field = db.query(models.ForceField.inner_xml).first()
+        remaining_force_field = db.query(models.ForceField.inner_content).first()
         assert "Refit" not in remaining_force_field
 
     def test_delete_not_found(self, db: Session):

--- a/nonbonded/tests/backend/crud/utilities/comparison.py
+++ b/nonbonded/tests/backend/crud/utilities/comparison.py
@@ -267,8 +267,8 @@ def compare_optimizations(
 
     # Check that both optimizations start from the same force field.
     assert (
-        optimization_1.initial_force_field.inner_xml
-        == optimization_2.initial_force_field.inner_xml
+        optimization_1.initial_force_field.inner_content
+        == optimization_2.initial_force_field.inner_content
     )
 
     # Check that both optimizations are training the same parameters.
@@ -474,8 +474,8 @@ def compare_optimization_results(
             assert field_1 == field_2
 
     assert (
-        optimization_result_1.refit_force_field.inner_xml
-        == optimization_result_2.refit_force_field.inner_xml
+        optimization_result_1.refit_force_field.inner_content
+        == optimization_result_2.refit_force_field.inner_content
     )
 
 
@@ -545,7 +545,10 @@ def compare_benchmarks(
     if benchmark_1.force_field is None:
         assert benchmark_1.force_field == benchmark_2.force_field
     else:
-        assert benchmark_1.force_field.inner_xml == benchmark_2.force_field.inner_xml
+        assert (
+            benchmark_1.force_field.inner_content
+            == benchmark_2.force_field.inner_content
+        )
 
     # Make sure both benchmarks are analyzing the same environments
     assert len(benchmark_1.analysis_environments) == len(

--- a/nonbonded/tests/backend/crud/utilities/create.py
+++ b/nonbonded/tests/backend/crud/utilities/create.py
@@ -22,7 +22,7 @@ from nonbonded.library.utilities.environments import ChemicalEnvironment
 
 
 def create_force_field(inner_text="") -> ForceField:
-    return ForceField(inner_xml=f"<root>{inner_text}</root>")
+    return ForceField(inner_content=f"<root>{inner_text}</root>")
 
 
 def create_author():

--- a/nonbonded/tests/library/models/test_projects.py
+++ b/nonbonded/tests/library/models/test_projects.py
@@ -10,7 +10,7 @@ from nonbonded.library.models.projects import Benchmark, Optimization, Project, 
 @pytest.fixture(scope="module")
 def valid_optimization_kwargs():
 
-    force_field = ForceField(inner_xml=" ")
+    force_field = ForceField(inner_content=" ")
     parameters = [Parameter(handler_type=" ", smirks=" ", attribute_name=" ")]
 
     return {
@@ -41,7 +41,7 @@ def valid_benchmark_kwargs():
         "test_set_ids": ["id"],
         "analysis_environments": [],
         "optimization_id": None,
-        "force_field": ForceField(inner_xml=" "),
+        "force_field": ForceField(inner_content=" "),
     }
 
 
@@ -71,7 +71,7 @@ def test_benchmark_validation(valid_benchmark_kwargs):
         **{
             **valid_benchmark_kwargs,
             "optimization_id": None,
-            "force_field": ForceField(inner_xml=" "),
+            "force_field": ForceField(inner_content=" "),
         }
     )
 
@@ -85,7 +85,7 @@ def test_benchmark_validation(valid_benchmark_kwargs):
             **{
                 **valid_benchmark_kwargs,
                 "optimization_id": " ",
-                "force_field": ForceField(inner_xml=" "),
+                "force_field": ForceField(inner_content=" "),
             }
         )
 


### PR DESCRIPTION
## Description
This PR renames the force field `inner_xml` attribute to `inner_content` as there is nothing that makes it specifically for XML, and it can in fact store any string representation of a force field.

## Status
- [X] Ready to go