### PR TITLE
Pin the OpenFF Toolkit <0.7.0 until ForceBalance is Compatible

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -18,7 +18,7 @@ dependencies:
   - forcebalance >=1.7.2
   - jinja2
   - numpy
-  - openforcefield
+  - openforcefield <0.7.0
   - openff-evaluator >=0.1.0
   - pandas
   - pydantic


### PR DESCRIPTION
## Description
This PR pins the OpenFF toolkit to versions < 0.7.0 until ForceBalance has been made compatible, especially the '[SMIRNOFF hack](https://github.com/leeping/forcebalance/blob/91e3be696d91489d289ca13444435e9d6180b520/src/smirnoff_hack.py)'.

## Status
- [X] Ready to go