### PR TITLE
Fix Missing Comma Between DOI Regex Patterns

### DIFF
--- a/nonbonded/library/curation/components/freesolv.py
+++ b/nonbonded/library/curation/components/freesolv.py
@@ -56,9 +56,9 @@ class ImportFreeSolv(Component):
         # From https://www.crossref.org/blog/dois-and-matching-regular-expressions/
         doi_patterns = [
             r"^10.\d{4,9}/[-._;()/:A-Z0-9]+$",
-            r"^10.1002/[^\s]+$"
-            r"^10.\d{4}/\d+-\d+X?(\d+)\d+<[\d\w]+:[\d\w]*>\d+.\d+.\w+;\d$"
-            r"^10.1021/\w\w\d+$"
+            r"^10.1002/[^\s]+$",
+            r"^10.\d{4}/\d+-\d+X?(\d+)\d+<[\d\w]+:[\d\w]*>\d+.\d+.\w+;\d$",
+            r"^10.1021/\w\w\d+$",
             r"^10.1207/[\w\d]+\&\d+_\d+$",
         ]
 


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in #30 whereby the DOI regex patterns were not separated by strings, and were instead concatenated together.

## Status
- [X] Ready to go