### PR TITLE
Support OpenFF Evaluator ForceFieldSource Objects

### DIFF
--- a/nonbonded/cli/benchmark/run.py
+++ b/nonbonded/cli/benchmark/run.py
@@ -67,6 +67,7 @@ def run(
         RequestResult,
     )
     from openff.evaluator.datasets import PhysicalPropertyDataSet
+    from openff.evaluator.forcefield import ForceFieldSource
 
     from openforcefield.typing.engines.smirnoff import ForceField
 
@@ -109,7 +110,20 @@ def run(
         logger.info(message)
 
     # Load in the force field.
-    force_field = ForceField("force-field.offxml")
+    if os.path.isfile("force-field.offxml") and os.path.isfile("force-field.json"):
+        raise RuntimeError(
+            "Two valid force fields were found: force-field.offxml and force-field.json"
+        )
+    elif os.path.isfile("force-field.offxml"):
+        force_field = ForceField("force-field.offxml")
+    elif os.path.isfile("force-field.json"):
+        force_field = ForceFieldSource.from_json("force-field.json")
+    else:
+        raise RuntimeError(
+            "No valid force field could be found. Either a SMIRNOFF force field "
+            "(named force-field.offxml) or an OpenFF Evaluator force field source "
+            "(named force-field.json) must be present in the current directory."
+        )
 
     # Load in the data set.
     if existing_results is None:

--- a/nonbonded/library/factories/projects/benchmark.py
+++ b/nonbonded/library/factories/projects/benchmark.py
@@ -68,6 +68,10 @@ class BenchmarkFactory:
     ):
 
         from openff.evaluator.client import RequestOptions
+        from openff.evaluator.forcefield import ForceFieldSource
+        from openforcefield.typing.engines.smirnoff.forcefield import (
+            ForceField as SMIRNOFFForceField,
+        )
 
         cls.generate_directory_structure(benchmark)
 
@@ -90,7 +94,10 @@ class BenchmarkFactory:
                 )
                 force_field = optimization_results.refit_force_field.to_openff()
 
-            force_field.to_file("force-field.offxml", io_format="offxml")
+            if isinstance(force_field, SMIRNOFFForceField):
+                force_field.to_file("force-field.offxml", io_format="offxml")
+            elif isinstance(force_field, ForceFieldSource):
+                force_field.json("force-field.json")
 
             # Retrieve the data set.
             test_sets: List[DataSet] = [

--- a/nonbonded/tests/library/models/test_forcefield.py
+++ b/nonbonded/tests/library/models/test_forcefield.py
@@ -1,0 +1,23 @@
+from nonbonded.library.models.forcefield import ForceField
+
+
+def test_to_from_openff_smirnoff():
+    """Tests that a force field model can be created from a
+    force field.
+    """
+    from openforcefield.typing.engines.smirnoff.forcefield import (
+        ForceField as OFFForceField,
+    )
+
+    force_field = ForceField.from_openff(OFFForceField("openff-1.0.0.offxml"))
+    assert isinstance(force_field.to_openff(), OFFForceField)
+
+
+def test_to_from_openff_evaluator():
+    """Tests that a force field model can be created from a
+    force field.
+    """
+    from openff.evaluator.forcefield import TLeapForceFieldSource
+
+    force_field = ForceField.from_openff(TLeapForceFieldSource())
+    assert isinstance(force_field.to_openff(), TLeapForceFieldSource)


### PR DESCRIPTION
## Description
This PR adds support for OpenFF Evaluator `ForceFieldSource` objects as the target force field to benchmark.

## Status
- [x] Ready to go