### PR TITLE
Decouple Internal Units from OpenFF Evaluator

### DIFF
--- a/nonbonded/library/models/results.py
+++ b/nonbonded/library/models/results.py
@@ -127,6 +127,8 @@ class DataSetResult(BaseORM):
         results_entries = []
         results_rows = []
 
+        internal_units = DataSetEntry.default_units()
+
         for identifier in reference_entries_by_id:
 
             if identifier not in estimated_entries_by_id:
@@ -146,14 +148,13 @@ class DataSetResult(BaseORM):
             assert reference_entry.property_type == estimated_entry.__class__.__name__
             assert len(reference_entry.components) == len(estimated_entry.substance)
 
-            property_class = estimated_entry.__class__
-            default_units = property_class.default_unit()
+            internal_unit = internal_units[reference_entry.property_type]
 
             results_entry = DataSetResultEntry(
                 reference_id=reference_entry.id,
-                estimated_value=estimated_entry.value.to(default_units).magnitude,
+                estimated_value=estimated_entry.value.to(internal_unit).magnitude,
                 estimated_std_error=estimated_entry.uncertainty.to(
-                    default_units
+                    internal_unit
                 ).magnitude,
                 category=components_to_category(
                     reference_entry.components, analysis_environments

--- a/nonbonded/library/plotting/utilities.py
+++ b/nonbonded/library/plotting/utilities.py
@@ -1,9 +1,11 @@
 from typing import Optional, Tuple
 
+from nonbonded.library.models.datasets import DataSetEntry
+
 
 def property_type_to_title(property_type: str, n_components: int):
 
-    from openff.evaluator import properties, unit
+    from openff.evaluator import unit
 
     abbreviations = {
         "Density": r"\rho",
@@ -14,8 +16,7 @@ def property_type_to_title(property_type: str, n_components: int):
         "SolvationFreeEnergy": r"G_{solv}",
     }
 
-    property_class = getattr(properties, property_type)
-    property_unit = property_class.default_unit()
+    property_unit = unit.Unit(DataSetEntry.default_units()[property_type])
 
     unit_string = (
         "" if property_unit == unit.dimensionless else f" ({property_unit:~P})"

--- a/nonbonded/tests/library/models/test_datasets.py
+++ b/nonbonded/tests/library/models/test_datasets.py
@@ -74,11 +74,11 @@ def compare_properties(
 
     assert numpy.isclose(
         data_set_entry.value,
-        evaluator_property.value.to(evaluator_property.default_unit()).magnitude,
+        evaluator_property.value.to(data_set_entry.units).magnitude,
     )
     assert numpy.isclose(
         data_set_entry.std_error,
-        evaluator_property.uncertainty.to(evaluator_property.default_unit()).magnitude,
+        evaluator_property.uncertainty.to(data_set_entry.units).magnitude,
     )
 
     assert numpy.isclose(


### PR DESCRIPTION
## Description
This PR aims to make more clear which units data set entries should be provided in in a way which is decoupled from OpenFF Evaluator (although it is anticipated that the same default units will be used).

## Status
- [X] Ready to go