### PR TITLE
Fix Plotting the RMSE of a Target with No Categories

### DIFF
--- a/nonbonded/library/plotting/optimization.py
+++ b/nonbonded/library/plotting/optimization.py
@@ -375,7 +375,7 @@ def plot_target_rmse(
             data_rows.append(data_row)
 
     plot_data = pandas.DataFrame(data_rows)
-    
+
     if len(plot_data) == 0:
         return
 

--- a/nonbonded/library/plotting/optimization.py
+++ b/nonbonded/library/plotting/optimization.py
@@ -375,6 +375,9 @@ def plot_target_rmse(
             data_rows.append(data_row)
 
     plot_data = pandas.DataFrame(data_rows)
+    
+    if len(plot_data) == 0:
+        return
 
     # Extract the unique data types (e.g. property types) which will be plotted
     # in separate figures.


### PR DESCRIPTION
## Description
This PR fixes an error raised by the `plot_target_rmse` function when attempting to plot a result which does not have any categories assigned.

## Status
- [X] Ready to go