### PR TITLE
Allow RESTful API to Return Without Children

### DIFF
--- a/nonbonded/backend/api/dev/endpoints/datasets.py
+++ b/nonbonded/backend/api/dev/endpoints/datasets.py
@@ -25,8 +25,11 @@ class DataSetEndpoints(BaseCRUDEndpoint):
         db: Session = Depends(depends.get_db),
         skip: int = 0,
         limit: int = 100,
+        children: bool = True,
     ):
-        db_data_sets = DataSetCRUD.read_all(db, skip=skip, limit=limit)
+        db_data_sets = DataSetCRUD.read_all(
+            db, skip=skip, limit=limit, include_children=children
+        )
         return {"data_sets": db_data_sets}
 
     @staticmethod

--- a/nonbonded/backend/api/dev/endpoints/molsets.py
+++ b/nonbonded/backend/api/dev/endpoints/molsets.py
@@ -25,8 +25,11 @@ class MoleculeSetEndpoints(BaseCRUDEndpoint):
         db: Session = Depends(depends.get_db),
         skip: int = 0,
         limit: int = 100,
+        children: bool = True,
     ):
-        db_molecule_sets = MoleculeSetCRUD.read_all(db, skip=skip, limit=limit)
+        db_molecule_sets = MoleculeSetCRUD.read_all(
+            db, skip=skip, limit=limit, include_children=children
+        )
         return {"molecule_sets": db_molecule_sets}
 
     @staticmethod

--- a/nonbonded/backend/api/dev/endpoints/projects.py
+++ b/nonbonded/backend/api/dev/endpoints/projects.py
@@ -39,9 +39,14 @@ class ProjectEndpoints(BaseCRUDEndpoint):
     @staticmethod
     @router.get("/", response_model=ProjectCollection)
     async def get_all(
-        skip: int = 0, limit: int = 100, db: Session = Depends(depends.get_db)
+        skip: int = 0,
+        limit: int = 100,
+        children: bool = True,
+        db: Session = Depends(depends.get_db),
     ):
-        db_projects = ProjectCRUD.read_all(db, skip=skip, limit=limit)
+        db_projects = ProjectCRUD.read_all(
+            db, skip=skip, limit=limit, include_children=children
+        )
         return ProjectCollection(projects=db_projects)
 
     @staticmethod

--- a/nonbonded/backend/database/crud/datasets.py
+++ b/nonbonded/backend/database/crud/datasets.py
@@ -72,11 +72,12 @@ class DataSetCRUD:
         return db_data_set
 
     @staticmethod
-    def read_all(db: Session, skip: int = 0, limit: int = 100):
+    def read_all(
+        db: Session, skip: int = 0, limit: int = 100, include_children: bool = True
+    ):
 
         data_sets = db.query(models.DataSet).offset(skip).limit(limit).all()
-
-        return [DataSetCRUD.db_to_model(x) for x in data_sets]
+        return [DataSetCRUD.db_to_model(x, include_children) for x in data_sets]
 
     @staticmethod
     def read(db: Session, data_set_id: str):
@@ -86,7 +87,7 @@ class DataSetCRUD:
         if db_data_set is None:
             raise DataSetNotFoundError(data_set_id)
 
-        return DataSetCRUD.db_to_model(db_data_set)
+        return DataSetCRUD.db_to_model(db_data_set, True)
 
     @staticmethod
     def create(db: Session, data_set: datasets.DataSet) -> models.DataSet:
@@ -105,15 +106,17 @@ class DataSetCRUD:
         return db_data_set
 
     @staticmethod
-    def db_to_model(db_data_set: models.DataSet) -> datasets.DataSet:
+    def db_to_model(
+        db_data_set: models.DataSet, include_children: bool = True
+    ) -> datasets.DataSet:
 
         # noinspection PyTypeChecker
         data_set = datasets.DataSet(
             id=db_data_set.id,
             description=db_data_set.description,
-            entries=[
-                DataSetEntryCRUD.db_to_model(entry) for entry in db_data_set.entries
-            ],
+            entries=[]
+            if not include_children
+            else [DataSetEntryCRUD.db_to_model(entry) for entry in db_data_set.entries],
             authors=db_data_set.authors,
         )
 
@@ -157,10 +160,12 @@ class MoleculeSetCRUD:
         return db_molecule_set
 
     @staticmethod
-    def read_all(db: Session, skip: int = 0, limit: int = 100):
+    def read_all(
+        db: Session, skip: int = 0, limit: int = 100, include_children: bool = True
+    ):
 
         molecule_sets = db.query(models.MoleculeSet).offset(skip).limit(limit).all()
-        return [MoleculeSetCRUD.db_to_model(x) for x in molecule_sets]
+        return [MoleculeSetCRUD.db_to_model(x, include_children) for x in molecule_sets]
 
     @staticmethod
     def read(db: Session, molecule_set_id: str):
@@ -189,13 +194,17 @@ class MoleculeSetCRUD:
         return db_molecule_set
 
     @staticmethod
-    def db_to_model(db_molecule_set: models.MoleculeSet) -> datasets.MoleculeSet:
+    def db_to_model(
+        db_molecule_set: models.MoleculeSet, include_children: bool = True
+    ) -> datasets.MoleculeSet:
 
         # noinspection PyTypeChecker
         molecule_set = datasets.MoleculeSet(
             id=db_molecule_set.id,
             description=db_molecule_set.description,
-            entries=[entry.smiles for entry in db_molecule_set.entries],
+            entries=[]
+            if not include_children
+            else [entry.smiles for entry in db_molecule_set.entries],
             authors=db_molecule_set.authors,
         )
 


### PR DESCRIPTION
## Description
This PR exposes an option for the RESTful API allowing top level data models to return without their children (i.e. study, data set entries etc). This allows the API to rapidly provide lightweight summaries of the available objects.

## Status
- [X] Ready to go