### PR TITLE
[PLOTLY] Enable x-error Bars

### DIFF
--- a/nonbonded/library/models/plotly.py
+++ b/nonbonded/library/models/plotly.py
@@ -93,9 +93,9 @@ class Trace(BaseModel, abc.ABC):
     x: List[Union[float, str]] = Field(..., description="The x-values of the data.")
     y: List[float] = Field(..., description="The y-values of the data.")
 
-    # error_x: Optional[ErrorBar] = Field(
-    #     None, description="The x-error bars associated with the data."
-    # )
+    error_x: Optional[ErrorBar] = Field(
+        None, description="The x-error bars associated with the data."
+    )
     error_y: Optional[ErrorBar] = Field(
         None, description="The y-error bars associated with the data."
     )

--- a/nonbonded/library/plotting/plotly/benchmark.py
+++ b/nonbonded/library/plotting/plotly/benchmark.py
@@ -160,11 +160,11 @@ def plot_scatter_results(
                         name=category,
                         x=[*category_data["Estimated Value"]],
                         y=[*category_data["Reference Value"]],
-                        # error_x=ErrorBar(
-                        #     symmetric=True,
-                        #     array=[*category_data["Estimated Std"]],
-                        #     arrayminus=None,
-                        # ),
+                        error_x=ErrorBar(
+                            symmetric=True,
+                            array=[*category_data["Estimated Std"]],
+                            arrayminus=None,
+                        ),
                         error_y=ErrorBar(
                             symmetric=True,
                             array=[*category_data["Reference Std"]],


### PR DESCRIPTION
## Description
This PR enables setting x-error bars on scatter plots.

## Status
- [X] Ready to go