### PR TITLE
[PLOTLY] Fix No Category and NaN Error Bars

### DIFF
--- a/nonbonded/library/plotting/plotly/benchmark.py
+++ b/nonbonded/library/plotting/plotly/benchmark.py
@@ -162,12 +162,16 @@ def plot_scatter_results(
                         y=[*category_data["Reference Value"]],
                         error_x=ErrorBar(
                             symmetric=True,
-                            array=[*category_data["Estimated Std"]],
+                            array=[
+                                *category_data["Estimated Std"].replace(numpy.nan, 0)
+                            ],
                             arrayminus=None,
                         ),
                         error_y=ErrorBar(
                             symmetric=True,
-                            array=[*category_data["Reference Std"]],
+                            array=[
+                                *category_data["Reference Std"].replace(numpy.nan, 0)
+                            ],
                             arrayminus=None,
                         ),
                         marker=MarkerStyle(color=category_colors[category]),

--- a/nonbonded/library/plotting/utilities.py
+++ b/nonbonded/library/plotting/utilities.py
@@ -90,7 +90,12 @@ def combine_data_set_results(
 
             # For now trim down the number of different categories and
             # shorten certain category names.
-            category = re.sub("[<>~]", "+", result_entry.category)
+            category = result_entry.category
+
+            if category is None:
+                category = "Uncategorized"
+
+            category = re.sub("[<>~]", "+", category)
             category = re.sub("Carboxylic Acid Ester", "Ester", category)
             category = re.sub("Carboxylic Acid", "Acid", category)
 


### PR DESCRIPTION
## Description
This PR fixes exceptions raised when a property has `None` for a category or has a `NaN` (likely caused by conversion of a `None` to pandas) as an error bar.

## Status
- [X] Ready to go