### PR TITLE
[PLOTLY] Fix REST Dependencies

### DIFF
--- a/nonbonded/library/plotting/utilities.py
+++ b/nonbonded/library/plotting/utilities.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 
 def property_type_to_title(property_type: str, n_components: int):
 
-    from openff.evaluator import unit
+    try:
+        from openff.evaluator import unit
+    except ImportError:
+        unit = None
 
     abbreviations = {
         "Density": r"\rho",
@@ -22,11 +25,15 @@ def property_type_to_title(property_type: str, n_components: int):
         "SolvationFreeEnergy": r"G_{solv}",
     }
 
-    property_unit = unit.Unit(DataSetEntry.default_units()[property_type])
+    unit_string = DataSetEntry.default_units()[property_type]
 
-    unit_string = (
-        "" if property_unit == unit.dimensionless else f" ({property_unit:~P})"
-    )
+    if unit is not None:
+
+        property_unit = unit.Unit(unit_string)
+
+        unit_string = (
+            "" if property_unit == unit.dimensionless else f" ({property_unit:~P})"
+        )
 
     abbreviation = abbreviations.get(property_type, property_type)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ psycopg2
 click
 requests
 git+git://github.com/openforcefield/openff-recharge@0.0.1-alpha.4#egg=openff-recharge
+pandas


### PR DESCRIPTION
## Description
This PR fixes the plotly endpoints which previously and unintentionally depended on having `openff-evaluator` installed. The `openff-evaluator` path is now made optional.

## Status
- [X] Ready to go