### PR TITLE
[PLOTLY] Make Pandas a Top Level Import

### DIFF
--- a/nonbonded/library/models/datasets.py
+++ b/nonbonded/library/models/datasets.py
@@ -1,6 +1,7 @@
 import abc
 from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
+import pandas
 import requests
 from pydantic import Field, conlist, validator
 from typing_extensions import Literal
@@ -16,7 +17,6 @@ from nonbonded.library.utilities.exceptions import (
 )
 
 if TYPE_CHECKING:
-    import pandas
     from openff.evaluator.datasets import PhysicalProperty, PhysicalPropertyDataSet
 
     PositiveFloat = float
@@ -169,7 +169,6 @@ class DataSetEntry(BaseORM):
 
     def to_series(self) -> "pandas.Series":
 
-        import pandas
         from openff.evaluator import properties, unit
 
         expected_unit = getattr(properties, self.property_type).default_unit()
@@ -275,7 +274,7 @@ class DataSet(_BaseSet):
     @classmethod
     def from_pandas(
         cls,
-        data_frame: "pandas.DataFrame",
+        data_frame: pandas.DataFrame,
         identifier: str,
         description: str,
         authors: List[Author],
@@ -308,9 +307,7 @@ class DataSet(_BaseSet):
 
         return data_set
 
-    def to_pandas(self) -> "pandas.DataFrame":
-
-        import pandas
+    def to_pandas(self) -> pandas.DataFrame:
 
         data_rows = [entry.to_series() for entry in self.entries]
         data_frame = pandas.DataFrame(data_rows)

--- a/nonbonded/library/models/results.py
+++ b/nonbonded/library/models/results.py
@@ -2,6 +2,7 @@ import abc
 import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
+import pandas
 import requests
 from pydantic import Field, conint, validator
 from typing_extensions import Literal
@@ -18,7 +19,6 @@ from nonbonded.library.utilities.exceptions import UnsupportedEndpointError
 
 if TYPE_CHECKING:
 
-    import pandas
     from openff.evaluator.datasets import PhysicalPropertyDataSet
 
     PositiveInt = int
@@ -104,9 +104,8 @@ class DataSetResult(BaseORM):
         reference_data_set: Union[DataSet, DataSetCollection],
         estimated_data_set: "PhysicalPropertyDataSet",
         analysis_environments: List[ChemicalEnvironment],
-    ) -> Tuple[List[DataSetResultEntry], "pandas.DataFrame"]:
+    ) -> Tuple[List[DataSetResultEntry], pandas.DataFrame]:
 
-        import pandas
         from openff.evaluator.datasets import PhysicalProperty
 
         if isinstance(reference_data_set, DataSet):
@@ -182,7 +181,7 @@ class DataSetResult(BaseORM):
     @classmethod
     def _results_frame_to_statistics(
         cls,
-        results_frame: "pandas.DataFrame",
+        results_frame: pandas.DataFrame,
         property_type: str,
         n_components: int,
         category: Optional[str],

--- a/nonbonded/library/plotting/utilities.py
+++ b/nonbonded/library/plotting/utilities.py
@@ -1,12 +1,11 @@
 import re
-from typing import TYPE_CHECKING, Dict, List
+from typing import Dict, List
+
+import pandas
 
 from nonbonded.library.models.datasets import DataSet, DataSetEntry
 from nonbonded.library.models.projects import Benchmark
 from nonbonded.library.models.results import BenchmarkResult
-
-if TYPE_CHECKING:
-    import pandas
 
 
 def property_type_to_title(property_type: str, n_components: int):
@@ -40,7 +39,7 @@ def combine_data_set_results(
     data_sets: List[DataSet],
     benchmarks: List[Benchmark],
     benchmark_results: List[BenchmarkResult],
-) -> "pandas.DataFrame":
+) -> pandas.DataFrame:
     """Combines a set of benchmarked results with their corresponding reference
     data set values into a pandas data frame which can be readily plotted.
 
@@ -69,8 +68,6 @@ def combine_data_set_results(
             * "Reference Std": The uncertainty in the reference value.
             * "Category": The category assigned to the data point.
     """
-    import pandas
-
     reference_data_points: Dict[int, DataSetEntry] = {
         entry.id: entry for data_set in data_sets for entry in data_set.entries
     }

--- a/nonbonded/library/statistics/statistics.py
+++ b/nonbonded/library/statistics/statistics.py
@@ -32,7 +32,6 @@ def _compute_statistics(measured_values, estimated_values, statistics):
     list of StatisticType
         Human readable labels for each of the statistics.
     """
-    import numpy
     import scipy.stats
 
     if statistics is None:
@@ -98,8 +97,6 @@ def _compute_bootstrapped_statistics(
     bootstrap_iterations: int
         The number of bootstrap iterations to perform.
     """
-    import numpy
-
     sample_count = len(measured_values)
 
     # Compute the mean of the statistics.
@@ -258,9 +255,6 @@ def compute_statistics(
     dict of StatisticType and tuple of float and float
         The 95% confidence intervals of each statistic.
     """
-
-    import numpy
-
     measured_std = measured_std.astype(numpy.float64)
     measured_std[numpy.isnan(measured_std)] = 0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ psycopg2
 click
 requests
 git+git://github.com/openforcefield/openff-recharge@0.0.1-alpha.4#egg=openff-recharge
+pandas


### PR DESCRIPTION
## Description
This PR makes `pandas` a top-level import as it is now used directly by the RESTful API while constructing `plotly` plots.

## Status
- [X] Ready to go