### PR TITLE
Only Store Evaluator Train and Test Sets Once

### DIFF
--- a/nonbonded/cli/projects/benchmark/run.py
+++ b/nonbonded/cli/projects/benchmark/run.py
@@ -7,6 +7,7 @@ from click_option_group import optgroup
 
 from nonbonded.cli.utilities import generate_click_command
 from nonbonded.library.factories.inputs.evaluator import EvaluatorServerConfig
+from nonbonded.library.models.datasets import DataSetCollection
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,6 @@ def _prepare_restart(
     """
 
     from openff.evaluator.client import RequestResult
-    from openff.evaluator.datasets import PhysicalPropertyDataSet
 
     # Check for existing results files to restart from.
     existing_results: Optional[RequestResult] = None
@@ -110,7 +110,9 @@ def _prepare_restart(
 
     # Load in the data set.
     if existing_results is None:
-        data_set = PhysicalPropertyDataSet.from_json("test-set.json")
+        data_set = DataSetCollection.parse_file(
+            "test-set-collection.json"
+        ).to_evaluator()
     else:
         data_set = existing_results.unsuccessful_properties
 

--- a/nonbonded/library/factories/analysis/optimization.py
+++ b/nonbonded/library/factories/analysis/optimization.py
@@ -7,7 +7,8 @@ from glob import glob
 from typing import Optional
 
 from nonbonded.library.factories.analysis import AnalysisFactory
-from nonbonded.library.models.datasets import DataSetCollection
+from nonbonded.library.models.authors import Author
+from nonbonded.library.models.datasets import DataSet
 from nonbonded.library.models.forcefield import ForceField
 from nonbonded.library.models.projects import Optimization
 from nonbonded.library.models.results import (
@@ -83,6 +84,7 @@ class OptimizationAnalysisFactory(AnalysisFactory):
     ) -> Optional[EvaluatorTargetResult]:
 
         from openff.evaluator.client import RequestResult
+        from openff.evaluator.datasets import PhysicalPropertyDataSet
 
         results_path = os.path.join(target_directory, "results.json")
 
@@ -90,8 +92,13 @@ class OptimizationAnalysisFactory(AnalysisFactory):
             return None
 
         # Load the reference data set
-        reference_data_set = DataSetCollection.parse_file(
-            os.path.join("targets", target.id, "training-set-collection.json")
+        reference_data_set = DataSet.from_pandas(
+            PhysicalPropertyDataSet.from_json(
+                os.path.join("targets", target.id, "training-set.json")
+            ).to_pandas(),
+            identifier="empty",
+            description="empty",
+            authors=[Author(name="empty", email="email@email.com", institute="empty")],
         )
 
         results = RequestResult.from_json(results_path)

--- a/nonbonded/library/factories/inputs/benchmark.py
+++ b/nonbonded/library/factories/inputs/benchmark.py
@@ -54,9 +54,6 @@ class BenchmarkInputFactory(InputFactory):
         with open("test-set-collection.json", "w") as file:
             file.write(test_set_collection.json())
 
-        evaluator_set = test_set_collection.to_evaluator()
-        evaluator_set.json("test-set.json")
-
     @classmethod
     def _retrieve_results(cls, benchmark: Benchmark):
         """Retrieves the full results for a benchmark.

--- a/nonbonded/library/factories/inputs/optimization.py
+++ b/nonbonded/library/factories/inputs/optimization.py
@@ -191,9 +191,6 @@ class OptimizationInputFactory(InputFactory):
         ]
         training_set_collection = DataSetCollection(data_sets=training_sets)
 
-        with open("training-set-collection.json", "w") as file:
-            file.write(training_set_collection.json())
-
         evaluator_set = training_set_collection.to_evaluator()
         evaluator_set.json("training-set.json")
 

--- a/nonbonded/tests/cli/projects/run/test_benchmark.py
+++ b/nonbonded/tests/cli/projects/run/test_benchmark.py
@@ -23,6 +23,7 @@ from nonbonded.library.factories.inputs.evaluator import (
     DaskLocalClusterConfig,
     EvaluatorServerConfig,
 )
+from nonbonded.library.models.datasets import DataSetCollection
 from nonbonded.library.utilities import temporary_cd
 from nonbonded.tests.utilities.comparison import does_not_raise
 from nonbonded.tests.utilities.factory import create_data_set
@@ -66,8 +67,10 @@ def test_prepare_restart(
     with temporary_cd():
 
         # Create a mock data set
-        original_data_set = create_data_set("data-set-1", 1).to_evaluator()
-        original_data_set.json("test-set.json")
+        original_data_set = DataSetCollection(
+            data_sets=[create_data_set("data-set-1", 1)]
+        )
+        original_data_set.to_file("test-set-collection.json")
 
         if original_existing_results is not None:
             original_existing_results.json("results.json")

--- a/nonbonded/tests/library/factories/analysis/test_optimization.py
+++ b/nonbonded/tests/library/factories/analysis/test_optimization.py
@@ -72,8 +72,8 @@ def test_analyze_evaluator_target(tmpdir):
 
         # Create a dummy data set and estimated result.
         reference_data_set = create_data_set("data-set-1", 1)
-        DataSetCollection(data_sets=[reference_data_set]).to_file(
-            os.path.join("targets", target.id, "training-set-collection.json")
+        DataSetCollection(data_sets=[reference_data_set]).to_evaluator().json(
+            os.path.join("targets", target.id, "training-set.json")
         )
 
         results = RequestResult()

--- a/nonbonded/tests/library/factories/inputs/test_benchmark.py
+++ b/nonbonded/tests/library/factories/inputs/test_benchmark.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from openff.evaluator.datasets import PhysicalPropertyDataSet
 from openff.evaluator.forcefield import TLeapForceFieldSource
 
 from nonbonded.library.factories.inputs.benchmark import BenchmarkInputFactory
@@ -120,10 +119,6 @@ class TestBenchmarkInputFactory:
                 "test-set-collection.json"
             )
             assert data_set_collection.data_sets[0].json() == data_set.json()
-
-            assert os.path.isfile("test-set.json")
-            off_data_set = PhysicalPropertyDataSet.from_json("test-set.json")
-            assert off_data_set.json() == data_set.to_evaluator().json()
 
     def test_retrieve_results(self, benchmark, requests_mock):
 

--- a/nonbonded/tests/library/factories/inputs/test_optimization.py
+++ b/nonbonded/tests/library/factories/inputs/test_optimization.py
@@ -9,7 +9,6 @@ from openff.evaluator.properties import Density
 from openforcefield.typing.engines.smirnoff import ForceField as OFFForceField
 
 from nonbonded.library.factories.inputs.optimization import OptimizationInputFactory
-from nonbonded.library.models.datasets import DataSetCollection
 from nonbonded.library.models.forcefield import Parameter
 from nonbonded.library.models.projects import Optimization
 from nonbonded.library.models.results import OptimizationResult
@@ -160,12 +159,6 @@ class TestOptimizationInputFactory:
         with temporary_cd():
 
             OptimizationInputFactory._generate_evaluator_target(target, 8000)
-
-            assert os.path.isfile("training-set-collection.json")
-            data_set_collection = DataSetCollection.parse_file(
-                "training-set-collection.json"
-            )
-            assert data_set_collection.data_sets[0].json() == data_set.json()
 
             assert os.path.isfile("training-set.json")
             off_data_set = PhysicalPropertyDataSet.from_json("training-set.json")


### PR DESCRIPTION
## Description
This PR changes the input factory to only store one copy of an evaluator train / test set. For benchmarks only `test-set-collection.json` (the `nonbonded` data set model) is needed, and for optimisations only `training-set.json` is created for evaluator targets (the `evaluator` model required by force balance).

This should improve the clarity of the directory structures and reduce the likelihood of data desynchronisation.

## Status
- [X] Ready to go