### PR TITLE
[REST] Attach Pagination Metadata Collections

### DIFF
--- a/nonbonded/backend/api/dev/endpoints/datasets.py
+++ b/nonbonded/backend/api/dev/endpoints/datasets.py
@@ -14,6 +14,7 @@ from nonbonded.library.models.datasets import (
     QCDataSet,
     QCDataSetCollection,
 )
+from nonbonded.library.models.models import CollectionMeta
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -32,10 +33,17 @@ class DataSetEndpoints(BaseCRUDEndpoint):
         limit: int = 100,
         children: bool = True,
     ):
-        db_data_sets = DataSetCRUD.read_all(
-            db, skip=skip, limit=limit, include_children=children
+
+        data_set_collection = DataSetCollection(
+            data_sets=DataSetCRUD.read_all(
+                db, skip=skip, limit=limit, include_children=children
+            )
         )
-        return {"data_sets": db_data_sets}
+        data_set_collection.metadata = CollectionMeta(
+            skip=skip, limit=limit, total_records=DataSetCRUD.n_total(db)
+        )
+
+        return data_set_collection
 
     @staticmethod
     @router.get("/phys-prop/{data_set_id}")
@@ -74,10 +82,17 @@ class QCDataSetEndpoints(BaseCRUDEndpoint):
         limit: int = 100,
         children: bool = True,
     ):
-        db_qc_data_sets = QCDataSetCRUD.read_all(
-            db, skip=skip, limit=limit, include_children=children
+
+        data_set_collection = QCDataSetCollection(
+            data_sets=QCDataSetCRUD.read_all(
+                db, skip=skip, limit=limit, include_children=children
+            )
         )
-        return {"data_sets": db_qc_data_sets}
+        data_set_collection.metadata = CollectionMeta(
+            skip=skip, limit=limit, total_records=QCDataSetCRUD.n_total(db)
+        )
+
+        return data_set_collection
 
     @staticmethod
     @router.get("/qc/{qc_data_set_id}")

--- a/nonbonded/backend/api/dev/endpoints/projects.py
+++ b/nonbonded/backend/api/dev/endpoints/projects.py
@@ -16,6 +16,7 @@ from nonbonded.backend.database.crud.results import (
     BenchmarkResultCRUD,
     OptimizationResultCRUD,
 )
+from nonbonded.library.models.models import CollectionMeta
 from nonbonded.library.models.projects import (
     Benchmark,
     BenchmarkCollection,
@@ -44,10 +45,16 @@ class ProjectEndpoints(BaseCRUDEndpoint):
         children: bool = True,
         db: Session = Depends(depends.get_db),
     ):
-        db_projects = ProjectCRUD.read_all(
-            db, skip=skip, limit=limit, include_children=children
+        project_collection = ProjectCollection(
+            projects=ProjectCRUD.read_all(
+                db, skip=skip, limit=limit, include_children=children
+            )
         )
-        return ProjectCollection(projects=db_projects)
+        project_collection.metadata = CollectionMeta(
+            skip=skip, limit=limit, total_records=ProjectCRUD.n_total(db)
+        )
+
+        return project_collection
 
     @staticmethod
     @router.get("/{project_id}", response_model=Project)

--- a/nonbonded/backend/database/crud/datasets.py
+++ b/nonbonded/backend/database/crud/datasets.py
@@ -63,6 +63,11 @@ class DataSetEntryCRUD:
 
 class DataSetCRUD:
     @staticmethod
+    def n_total(db: Session):
+        """Returns the total number of data sets in the database."""
+        return db.query(models.DataSet.id).count()
+
+    @staticmethod
     def query(db: Session, data_set_id: str):
 
         db_data_set = (
@@ -148,6 +153,11 @@ class DataSetCRUD:
 
 
 class QCDataSetCRUD:
+    @staticmethod
+    def n_total(db: Session):
+        """Returns the total number of data sets in the database."""
+        return db.query(models.QCDataSet.id).count()
+
     @staticmethod
     def query(db: Session, qc_data_set_id: str):
 

--- a/nonbonded/backend/database/crud/projects.py
+++ b/nonbonded/backend/database/crud/projects.py
@@ -858,6 +858,11 @@ class StudyCRUD:
 
 class ProjectCRUD:
     @staticmethod
+    def n_total(db: Session):
+        """Returns the total number of projects in the database."""
+        return db.query(models.Project.id).count()
+
+    @staticmethod
     def query(db: Session, project_id: str):
 
         db_project = (

--- a/nonbonded/library/models/datasets.py
+++ b/nonbonded/library/models/datasets.py
@@ -269,9 +269,7 @@ class DataSet(_BaseSet):
         "numbers are incompatible.",
     )
 
-    entries: conlist(DataSetEntry, min_items=1) = Field(
-        ..., description="The entries in the data set."
-    )
+    entries: List[DataSetEntry] = Field(..., description="The entries in the data set.")
 
     @classmethod
     def from_pandas(

--- a/nonbonded/library/models/models.py
+++ b/nonbonded/library/models/models.py
@@ -1,13 +1,26 @@
 import abc
 import logging
-from typing import Callable, Type, TypeVar
+from typing import Callable, Optional, Type, TypeVar
 
 import requests
+from pydantic import Field
 from pydantic.main import BaseModel
 
 from nonbonded.library.config import settings
 
 T = TypeVar("T", bound="BaseREST")
+
+
+class CollectionMeta(BaseModel):
+    """A data model which stores metadata about a retrieved collection, such as
+    pagination information."""
+
+    skip: int = Field(..., description="The number of skipped records.")
+    limit: int = Field(..., description="The maximum number of records returned.")
+
+    total_records: int = Field(
+        ..., description="The total number of records in the collection"
+    )
 
 
 class BaseORM(BaseModel, abc.ABC):
@@ -131,6 +144,13 @@ class BaseREST(BaseORM, abc.ABC):
 
 
 class BaseRESTCollection(BaseORM, abc.ABC):
+
+    metadata: Optional[CollectionMeta] = Field(
+        None,
+        description="Metadata associated with a collection retrieved from a RESTful "
+        "API such as pagination information.",
+    )
+
     @classmethod
     @abc.abstractmethod
     def _get_endpoint(cls, **kwargs):

--- a/nonbonded/tests/backend/api/test_data_sets.py
+++ b/nonbonded/tests/backend/api/test_data_sets.py
@@ -49,6 +49,11 @@ class TestDataSetEndpoints(BaseTestEndpoints):
         assert rest_data_collection is not None
         assert len(rest_data_collection.data_sets) == 1
 
+        assert rest_data_collection.metadata is not None
+        assert rest_data_collection.metadata.skip == 0
+        assert rest_data_collection.metadata.limit == 100
+        assert rest_data_collection.metadata.total_records == 1
+
         compare_pydantic_models(data_set, rest_data_collection.data_sets[0])
 
 
@@ -84,5 +89,10 @@ class TestQCDataSetEndpoints(BaseTestEndpoints):
 
         assert rest_qc_data_set_collection is not None
         assert len(rest_qc_data_set_collection.data_sets) == 1
+
+        assert rest_qc_data_set_collection.metadata is not None
+        assert rest_qc_data_set_collection.metadata.skip == 0
+        assert rest_qc_data_set_collection.metadata.limit == 100
+        assert rest_qc_data_set_collection.metadata.total_records == 1
 
         compare_pydantic_models(qc_data_set, rest_qc_data_set_collection.data_sets[0])

--- a/nonbonded/tests/backend/api/test_projects.py
+++ b/nonbonded/tests/backend/api/test_projects.py
@@ -59,6 +59,11 @@ class TestProjectEndpoints(BaseTestEndpoints):
         project = commit_project(db)
         rest_collection = ProjectCollection.from_rest(requests_class=rest_client)
 
+        assert rest_collection.metadata is not None
+        assert rest_collection.metadata.skip == 0
+        assert rest_collection.metadata.limit == 100
+        assert rest_collection.metadata.total_records == 1
+
         assert rest_collection is not None
         assert len(rest_collection.projects) == 1
 


### PR DESCRIPTION
## Description
This PR adds pagination metadata to collections retrieved from the RESTful API, including the skip, limit, and the total number of records in the database.

## Status
- [X] Ready to go