### PR TITLE
Store Calculation and Analysis Provenance

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -25,6 +25,7 @@ dependencies:
   - pandas
   - jinja2
   - email_validator
+  - pyyaml
 
     # Benchmark / optimization target dependencies
   - forcebalance >=1.7.5

--- a/nonbonded/backend/database/crud/results.py
+++ b/nonbonded/backend/database/crud/results.py
@@ -195,6 +195,14 @@ class ResultCRUD(abc.ABC):
             id=db_parent.identifier,
             study_id=db_parent_study.identifier,
             project_id=db_parent_project.identifier,
+            calculation_environment={
+                environment.name: environment.version
+                for environment in db_sub_study_result.calculation_environment
+            },
+            analysis_environment={
+                environment.name: environment.version
+                for environment in db_sub_study_result.analysis_environment
+            },
         )
 
     @classmethod
@@ -325,7 +333,7 @@ class BenchmarkResultCRUD(ResultCRUD):
 
     @classmethod
     def _db_model_kwargs(
-        cls, sub_study_result: BenchmarkResult, db_parent
+        cls, sub_study_result: BenchmarkResult, db_parent: models.Benchmark
     ) -> Dict[str, Any]:
 
         db = object_session(db_parent)
@@ -333,6 +341,18 @@ class BenchmarkResultCRUD(ResultCRUD):
         # noinspection PyTypeChecker
         return dict(
             parent=db_parent,
+            calculation_environment=[
+                models.SoftwareProvenance.unique(
+                    db, models.SoftwareProvenance(name=name, version=version)
+                )
+                for name, version in sub_study_result.calculation_environment.items()
+            ],
+            analysis_environment=[
+                models.SoftwareProvenance.unique(
+                    db, models.SoftwareProvenance(name=name, version=version)
+                )
+                for name, version in sub_study_result.analysis_environment.items()
+            ],
             data_set_result=models.DataSetResult(
                 statistic_entries=[
                     models.DataSetStatistic(
@@ -501,6 +521,18 @@ class OptimizationResultCRUD(ResultCRUD):
         # noinspection PyTypeChecker
         return dict(
             parent=db_parent,
+            calculation_environment=[
+                models.SoftwareProvenance.unique(
+                    db, models.SoftwareProvenance(name=name, version=version)
+                )
+                for name, version in sub_study_result.calculation_environment.items()
+            ],
+            analysis_environment=[
+                models.SoftwareProvenance.unique(
+                    db, models.SoftwareProvenance(name=name, version=version)
+                )
+                for name, version in sub_study_result.analysis_environment.items()
+            ],
             evaluator_target_results=[
                 EvaluatorTargetResultCRUD.model_to_db(
                     sub_study_result.target_results[iteration][db_target.identifier],

--- a/nonbonded/backend/database/models/__init__.py
+++ b/nonbonded/backend/database/models/__init__.py
@@ -25,6 +25,7 @@ from .results import (  # isort:skip
     EvaluatorTargetResult,
     RechargeTargetResult,
     OptimizationResult,
+    SoftwareProvenance,
 )
 from .targets.evaluator import EvaluatorDenominator, EvaluatorTarget  # isort:skip
 from .targets.recharge import (  # isort:skip
@@ -71,6 +72,7 @@ __all__ = [
     RechargeTarget,
     RechargeTargetResult,
     TargetResult,
+    SoftwareProvenance,
     Statistic,
     Study,
     SubStudy,

--- a/nonbonded/backend/database/models/results.py
+++ b/nonbonded/backend/database/models/results.py
@@ -23,6 +23,67 @@ data_set_result_categories_table = Table(
     ),
 )
 
+benchmark_calculation_environment_table = Table(
+    "benchmark_calculation_environment",
+    Base.metadata,
+    Column("results_id", Integer, ForeignKey("benchmark_results.id"), primary_key=True),
+    Column(
+        "software_id", Integer, ForeignKey("software_provenance.id"), primary_key=True
+    ),
+)
+benchmark_analysis_environment_table = Table(
+    "benchmark_analysis_environment",
+    Base.metadata,
+    Column("results_id", Integer, ForeignKey("benchmark_results.id"), primary_key=True),
+    Column(
+        "software_id", Integer, ForeignKey("software_provenance.id"), primary_key=True
+    ),
+)
+
+optimization_calculation_environment_table = Table(
+    "optimization_calculation_environment",
+    Base.metadata,
+    Column(
+        "results_id", Integer, ForeignKey("optimization_results.id"), primary_key=True
+    ),
+    Column(
+        "software_id", Integer, ForeignKey("software_provenance.id"), primary_key=True
+    ),
+)
+optimization_analysis_environment_table = Table(
+    "optimization_analysis_environment",
+    Base.metadata,
+    Column(
+        "results_id", Integer, ForeignKey("optimization_results.id"), primary_key=True
+    ),
+    Column(
+        "software_id", Integer, ForeignKey("software_provenance.id"), primary_key=True
+    ),
+)
+
+
+class SoftwareProvenance(UniqueMixin, Base):
+
+    __tablename__ = "software_provenance"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    name = Column(String(20), nullable=False)
+    version = Column(String(32), unique=True, nullable=False)
+
+    @classmethod
+    def _hash(cls, db_instance: "SoftwareProvenance"):
+        return hash((db_instance.name, db_instance.version))
+
+    @classmethod
+    def _query(cls, db: Session, db_instance: "SoftwareProvenance") -> Query:
+
+        return (
+            db.query(SoftwareProvenance)
+            .filter(SoftwareProvenance.name == db_instance.name)
+            .filter(SoftwareProvenance.version == db_instance.version)
+        )
+
 
 class Statistic(Base):
 
@@ -136,6 +197,15 @@ class BenchmarkResult(Base):
         "DataSetResult", uselist=False, cascade="all, delete-orphan", single_parent=True
     )
 
+    calculation_environment = relationship(
+        "SoftwareProvenance",
+        secondary=benchmark_calculation_environment_table,
+    )
+    analysis_environment = relationship(
+        "SoftwareProvenance",
+        secondary=benchmark_analysis_environment_table,
+    )
+
 
 class TargetResult(Base):
 
@@ -206,4 +276,13 @@ class OptimizationResult(Base):
         secondary=results_force_field_table,
         backref="results",
         uselist=False,
+    )
+
+    calculation_environment = relationship(
+        "SoftwareProvenance",
+        secondary=optimization_calculation_environment_table,
+    )
+    analysis_environment = relationship(
+        "SoftwareProvenance",
+        secondary=optimization_analysis_environment_table,
     )

--- a/nonbonded/library/factories/analysis/analysis.py
+++ b/nonbonded/library/factories/analysis/analysis.py
@@ -1,8 +1,11 @@
 import abc
+import errno
 import logging
+import os
 from typing import TypeVar
 
 from nonbonded.library.models.projects import Benchmark, Optimization
+from nonbonded.library.utilities.provenance import summarise_conda_environment
 
 logger = logging.getLogger(__name__)
 
@@ -43,3 +46,25 @@ class AnalysisFactory(abc.ABC):
             analysing the results of past studies not generated using the framework.
         """
         raise NotImplementedError()
+
+    @classmethod
+    def _parse_calculation_environment(cls):
+        """Attempts to parse the versions of the main software used to run the
+        optimization from a conda environment file produced by ``conda env export``."""
+
+        # Find the calculation environments.
+        file_name = (
+            "conda_env.yaml"
+            if os.path.isfile("conda_env.yaml")
+            else "conda-env.yaml"
+            if os.path.isfile("conda-env.yaml")
+            else None
+        )
+
+        if file_name is None:
+
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), "conda-env.yaml"
+            )
+
+        return summarise_conda_environment(file_name)

--- a/nonbonded/library/factories/analysis/benchmark.py
+++ b/nonbonded/library/factories/analysis/benchmark.py
@@ -6,6 +6,7 @@ from nonbonded.library.models.datasets import DataSetCollection
 from nonbonded.library.models.projects import Benchmark
 from nonbonded.library.models.results import BenchmarkResult
 from nonbonded.library.utilities.migration import reindex_results
+from nonbonded.library.utilities.provenance import summarise_current_versions
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,8 @@ class BenchmarkAnalysisFactory(AnalysisFactory):
             estimated_data_set=estimated_data_set,
             analysis_environments=benchmark.analysis_environments,
         )
+        benchmark_results.calculation_environment = cls._parse_calculation_environment()
+        benchmark_results.analysis_environment = summarise_current_versions()
 
         # Save the results
         with open(

--- a/nonbonded/library/factories/analysis/optimization.py
+++ b/nonbonded/library/factories/analysis/optimization.py
@@ -22,6 +22,7 @@ from nonbonded.library.models.targets import EvaluatorTarget, RechargeTarget
 from nonbonded.library.statistics.statistics import StatisticType, bootstrap_residuals
 from nonbonded.library.utilities.checkmol import components_to_categories
 from nonbonded.library.utilities.migration import reindex_results
+from nonbonded.library.utilities.provenance import summarise_current_versions
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +264,8 @@ class OptimizationAnalysisFactory(AnalysisFactory):
             project_id=optimization.project_id,
             study_id=optimization.study_id,
             id=optimization.id,
+            calculation_environment=cls._parse_calculation_environment(),
+            analysis_environment=summarise_current_versions(),
             target_results=target_results,
             refit_force_field=refit_force_field,
         )

--- a/nonbonded/library/models/results.py
+++ b/nonbonded/library/models/results.py
@@ -313,6 +313,20 @@ class SubStudyResult(BaseREST, abc.ABC):
     study_id: IdentifierStr = Field(..., description="The id of the parent study.")
     project_id: IdentifierStr = Field(..., description="The id of the parent project.")
 
+    calculation_environment: Dict[str, str] = Field(
+        {},
+        description="The versions of the main software packages used to generate the "
+        "raw data described by this results object. These will usually include the "
+        "version of `openff-evaluator`, `openff-recharge`, `openff-toolkit`.",
+    )
+    analysis_environment: Dict[str, str] = Field(
+        {},
+        description="The versions of the main software packages used to analyse the "
+        "raw data of a calculation and generate this results object. These will usually "
+        "include the version of `nonbonded`, `openff-evaluator`, `openff-recharge`, "
+        "`openff-toolkit` and `checkmol`.",
+    )
+
     @classmethod
     def _url_name(cls):
         return cls.__name__.replace("Result", "").lower() + "s"

--- a/nonbonded/library/utilities/provenance.py
+++ b/nonbonded/library/utilities/provenance.py
@@ -1,0 +1,149 @@
+import importlib
+from typing import Dict
+
+import packaging.version
+import yaml
+
+
+def summarise_conda_environment(environment_path: str) -> Dict[str, str]:
+    """Attempts to parse the versions of the key packages from a conda environment file
+    produced by ``conda env export``.
+
+    Currently the returned packages may (where present) include:
+
+        * forcebalance
+        * nonbonded
+        * openff-evaluator
+        * openff-recharge
+        * pint
+        * openmm
+        * openmmtools
+        * yank
+        * pymbar
+        * openforcefield
+        * openff-toolkit
+        * openeye-toolkits
+        * rdkit
+        * ambertools
+
+    Parameters
+    ----------
+    environment_path
+        The path to the conda environment file.
+
+    Returns
+    -------
+        A dictionary of package names and corresponding version strings.
+    """
+
+    with open(environment_path) as file:
+        environment = yaml.safe_load(file)
+
+    # Find the relevant dependencies.
+    dependencies = {
+        version_string.split("=")[0]: version_string.split("=")[1]
+        for version_string in environment["dependencies"]
+        if version_string != "pip"
+    }
+    dependencies.update(
+        {
+            dependency.split("==")[0]: dependency.split("==")[1]
+            for dependency in environment["dependencies"].get("pip", [])
+            if dependency.find("ambertools") >= 0
+        }
+    )
+
+    return {
+        name: str(packaging.version.parse(version))
+        for name, version in dependencies.items()
+        if name
+        in [
+            # Package to launch the calculation.
+            "forcebalance",
+            "nonbonded",
+            # Core target dependencies.
+            "openff-evaluator",
+            "openff-recharge",
+            # - Sub-target dependencies.
+            "pint",
+            "openmm",
+            "openmmtools",
+            "yank",
+            "pymbar",
+            # The OpenFF toolkit
+            "openforcefield",
+            "openff-toolkit",
+            # Cheminformatics toolkits.
+            "openeye-toolkits",
+            "rdkit",
+            "ambertools",
+        ]
+    }
+
+
+def summarise_current_versions() -> Dict[str, str]:
+    """Attempts to summarise the versions of the key packages which can currently be
+    imported.
+
+    Currently the returned packages (where present) include:
+
+        * forcebalance
+        * nonbonded
+        * openff-evaluator
+        * openff-recharge
+        * pint
+        * openmm
+        * openmmtools
+        * yank
+        * pymbar
+        * openforcefield
+        * openff-toolkit
+        * openeye-toolkits
+        * rdkit
+        * ambertools
+
+    Parameters
+    ----------
+    environment_path
+        The path to the conda environment file.
+
+    Returns
+    -------
+        A dictionary of package names and corresponding version strings.
+    """
+
+    packages = {
+        "forcebalance": "forcebalance",
+        "nonbonded": "nonbonded",
+        "openff-evaluator": "openff.evaluator",
+        "openff-recharge": "openff.recharge",
+        "pint": "pint",
+        "openmm": "simtk.openmm.version",
+        "openmmtools": "openmmtools",
+        "yank": "yank",
+        "pymbar": "pymbar",
+        "openforcefield": "openforcefield",
+        "openff-toolkit": "openff.toolkit",
+        "openeye-toolkits": "openeye",
+        "rdkit": "rdkit",
+    }
+
+    versions = {}
+
+    for name, import_path in packages.items():
+
+        try:
+            module = importlib.import_module(import_path)
+        except (ImportError, ModuleNotFoundError):
+            continue
+
+        if name == "pymbar":
+            versions[name] = module.version.short_version
+        elif name == "openmm":
+            versions[name] = module.short_version
+        else:
+            versions[name] = module.__version__
+
+        versions[name] = str(packaging.version.parse(versions[name]))
+
+    return versions

--- a/nonbonded/tests/conftest.py
+++ b/nonbonded/tests/conftest.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+import yaml
+
+
+@pytest.fixture()
+def dummy_conda_env(tmpdir, file_name: str = "conda-env.yaml") -> str:
+    """Creates a dummy conda-environment file in a temporary directory and returns
+    the path to the file."""
+
+    # Create a dummy environment
+    dummy_environment = {
+        "name": "test-env",
+        "channels": ["conda-forge"],
+        "dependencies": {
+            "forcebalance=1.7.5=py37h48f8a5e_0": None,
+            "nonbonded=0.0.1a4=pyh87d46a9_0": None,
+            "openff-evaluator=0.3.1=pyhf40f5cb_0": None,
+            "openff-recharge=0.0.1a6=pyhf40f5cb_0": None,
+            "pint=0.14=py_0": None,
+            "openmm=7.4.2=py37_cuda101_rc_1": None,
+            "yank=0.25.2=py37_1": None,
+            "pymbar=3.0.5=py37hc1659b7_0": None,
+            "openforcefield=0.8.0=pyh39e3cac_0": None,
+            "openeye-toolkits=2020.1.0=py37_0": None,
+            "rdkit=2020.09.2=py37h713bca6_0": None,
+            "xorg-xextproto=7.3.0=h14c3975_1002": None,
+            "openmmtools=0.20.0=py37_0": None,
+            "pip": ["ambertools==20.9", "amberlite==16.0"],
+        },
+    }
+
+    with open(os.path.join(tmpdir, file_name), "w") as file:
+        yaml.safe_dump(dummy_environment, file)
+
+    return os.path.join(tmpdir, file_name)

--- a/nonbonded/tests/library/factories/analysis/test_benchmark.py
+++ b/nonbonded/tests/library/factories/analysis/test_benchmark.py
@@ -3,11 +3,12 @@ import os
 
 from nonbonded.library.factories.analysis.benchmark import BenchmarkAnalysisFactory
 from nonbonded.library.models.datasets import DataSetCollection
+from nonbonded.library.models.results import BenchmarkResult
 from nonbonded.library.utilities import temporary_cd
 from nonbonded.tests.utilities.factory import create_benchmark, create_data_set
 
 
-def test_benchmark_analysis(caplog, monkeypatch):
+def test_benchmark_analysis(caplog, monkeypatch, dummy_conda_env):
 
     from openff.evaluator.client import RequestResult
     from openff.evaluator.datasets import PhysicalPropertyDataSet
@@ -33,7 +34,7 @@ def test_benchmark_analysis(caplog, monkeypatch):
     results.estimated_properties = estimated_data_set
     results.unsuccessful_properties = unsuccessful_properties
 
-    with temporary_cd():
+    with temporary_cd(os.path.dirname(dummy_conda_env)):
 
         # Save the expected input files.
         with open("benchmark.json", "w") as file:
@@ -54,3 +55,9 @@ def test_benchmark_analysis(caplog, monkeypatch):
 
         assert os.path.isdir("analysis")
         assert os.path.isfile(os.path.join("analysis", "benchmark-results.json"))
+
+        results_object = BenchmarkResult.parse_file(
+            os.path.join("analysis", "benchmark-results.json")
+        )
+        assert len(results_object.calculation_environment) > 0
+        assert len(results_object.analysis_environment) > 0

--- a/nonbonded/tests/library/factories/analysis/test_optimization.py
+++ b/nonbonded/tests/library/factories/analysis/test_optimization.py
@@ -166,7 +166,7 @@ def test_analyze_recharge_target_missing(tmpdir):
     )
 
 
-def test_optimization_analysis(monkeypatch, force_field):
+def test_optimization_analysis(monkeypatch, force_field, dummy_conda_env):
 
     optimization = create_optimization(
         "project-1",
@@ -179,7 +179,7 @@ def test_optimization_analysis(monkeypatch, force_field):
     )
     optimization.force_field = force_field
 
-    with temporary_cd():
+    with temporary_cd(os.path.dirname(dummy_conda_env)):
 
         # Save the expected results files.
         os.makedirs(os.path.join("result", "optimize"))

--- a/nonbonded/tests/library/utilities/test_provenance.py
+++ b/nonbonded/tests/library/utilities/test_provenance.py
@@ -1,0 +1,48 @@
+from nonbonded.library.utilities.provenance import (
+    summarise_conda_environment,
+    summarise_current_versions,
+)
+
+
+def test_summarise_conda_environment(dummy_conda_env):
+
+    detected_environments = summarise_conda_environment(dummy_conda_env)
+    expected_environment = {
+        "forcebalance": "1.7.5",
+        "nonbonded": "0.0.1a4",
+        "openff-evaluator": "0.3.1",
+        "openff-recharge": "0.0.1a6",
+        "pint": "0.14",
+        "openmm": "7.4.2",
+        "openmmtools": "0.20.0",
+        "yank": "0.25.2",
+        "pymbar": "3.0.5",
+        "openforcefield": "0.8.0",
+        "openeye-toolkits": "2020.1.0",
+        "rdkit": "2020.9.2",
+        "ambertools": "20.9",
+    }
+
+    assert detected_environments == expected_environment
+
+
+def test_summarise_current_versions(tmpdir):
+
+    detected_environments = summarise_current_versions()
+
+    assert all(
+        package in detected_environments
+        for package in [
+            "forcebalance",
+            "nonbonded",
+            "openff-evaluator",
+            "openff-recharge",
+            "pint",
+            "openmm",
+            "openmmtools",
+            "yank",
+            "pymbar",
+            "openforcefield",
+            "rdkit",
+        ]
+    )

--- a/nonbonded/tests/utilities/factory.py
+++ b/nonbonded/tests/utilities/factory.py
@@ -358,6 +358,8 @@ def create_benchmark_result(
         id=benchmark_id,
         study_id=study_id,
         project_id=project_id,
+        calculation_environment={"openff-evaluator": "1.0.0"},
+        analysis_environment={"nonbonded": "0.0.01a5"},
         data_set_result=DataSetResult(
             statistic_entries=statistics_entries, result_entries=results_entries
         ),
@@ -390,6 +392,8 @@ def create_optimization_result(
         id=optimization_id,
         study_id=study_id,
         project_id=project_id,
+        calculation_environment={"forcebalance": "1.0.0"},
+        analysis_environment={"nonbonded": "0.0.01a5"},
         target_results={
             0: {
                 **{


### PR DESCRIPTION
## Description
This PR (finally) adds support for storing the versions of the software which were used both when initially generating, and when analysis the results of an optimisation or benchmark.

The two sets of versions may differ as old results may be re-analysed at a later time such as when, for example, when changing are data points are categories.

The analysis versions are pulled directly from individual package `__version__` attributes as as part of the analysis process, while calculation versions are pulled from the root `conda-env.yaml` file which *must* have been generated when the initial optimization / benchmark was run.

## Status
- [X] Ready to go