### PR TITLE
Adds Endpoint for Updating Results

### DIFF
--- a/nonbonded/backend/api/dev/endpoints/projects.py
+++ b/nonbonded/backend/api/dev/endpoints/projects.py
@@ -210,7 +210,7 @@ class OptimizationResultEndpoints(BaseCRUDEndpoint):
     @router.get(
         "/{project_id}/studies/{study_id}/optimizations/{optimization_id}/results/"
     )
-    async def get_optimization_result(
+    async def get(
         project_id,
         study_id,
         optimization_id,
@@ -230,7 +230,7 @@ class OptimizationResultEndpoints(BaseCRUDEndpoint):
     @router.post(
         "/{project_id}/studies/{study_id}/optimizations/{optimization_id}/results/"
     )
-    async def post_optimization_result_result(
+    async def post(
         optimization_result: OptimizationResult,
         db: Session = Depends(depends.get_db),
         _: APIKey = Depends(check_access_token),
@@ -238,10 +238,21 @@ class OptimizationResultEndpoints(BaseCRUDEndpoint):
         return OptimizationResultEndpoints._post(db, optimization_result)
 
     @staticmethod
+    @router.put(
+        "/{project_id}/studies/{study_id}/optimizations/{optimization_id}/results/"
+    )
+    async def put(
+        optimization_result: OptimizationResult,
+        db: Session = Depends(depends.get_db),
+        _: APIKey = Depends(check_access_token),
+    ):
+        return OptimizationResultEndpoints._put(db, optimization_result)
+
+    @staticmethod
     @router.delete(
         "/{project_id}/studies/{study_id}/optimizations/{optimization_id}/results/"
     )
-    async def delete_optimization_result(
+    async def delete(
         project_id,
         study_id,
         optimization_id,
@@ -351,6 +362,15 @@ class BenchmarkResultEndpoints(BaseCRUDEndpoint):
         _: APIKey = Depends(check_access_token),
     ):
         return BenchmarkResultEndpoints._post(db, benchmark_result)
+
+    @staticmethod
+    @router.put("/{project_id}/studies/{study_id}/benchmarks/{benchmark_id}/results/")
+    async def put(
+        benchmark_result: BenchmarkResult,
+        db: Session = Depends(depends.get_db),
+        _: APIKey = Depends(check_access_token),
+    ):
+        return BenchmarkResultEndpoints._put(db, benchmark_result)
 
     @staticmethod
     @router.delete(

--- a/nonbonded/library/models/results.py
+++ b/nonbonded/library/models/results.py
@@ -15,7 +15,6 @@ from nonbonded.library.models.validators.string import IdentifierStr, NonEmptySt
 from nonbonded.library.statistics.statistics import StatisticType, compute_statistics
 from nonbonded.library.utilities.checkmol import components_to_categories
 from nonbonded.library.utilities.environments import ChemicalEnvironment
-from nonbonded.library.utilities.exceptions import UnsupportedEndpointError
 
 if TYPE_CHECKING:
 
@@ -343,7 +342,7 @@ class SubStudyResult(BaseREST, abc.ABC):
             f"/results/"
         )
 
-    def _post_endpoint(self):
+    def _edit_endpoint(self):
 
         return (
             f"{settings.API_URL}/projects/"
@@ -354,22 +353,15 @@ class SubStudyResult(BaseREST, abc.ABC):
             f"{self.id}"
             f"/results/"
         )
+
+    def _post_endpoint(self):
+        return self._edit_endpoint()
 
     def _put_endpoint(self):
-
-        raise UnsupportedEndpointError("Results cannot be updated via the RESTful API.")
+        return self._edit_endpoint()
 
     def _delete_endpoint(self):
-
-        return (
-            f"{settings.API_URL}/projects/"
-            f"{self.project_id}"
-            f"/studies/"
-            f"{self.study_id}"
-            f"/{self._url_name()}/"
-            f"{self.id}"
-            f"/results/"
-        )
+        return self._edit_endpoint()
 
     @classmethod
     def from_rest(


### PR DESCRIPTION
## Description

This PR exposes new `put` endpoints for updating already uploaded results. These endpoints are mainly expected to be used when the way `nonbonded` analyses results changes (especially due to fixed bugs) and all stored results should be updated.

## Status
- [X] Ready to go