### PR TITLE
Drop Parameter Evals for BCC Parameters

### DIFF
--- a/nonbonded/tests/library/factories/inputs/test_optimization.py
+++ b/nonbonded/tests/library/factories/inputs/test_optimization.py
@@ -79,11 +79,8 @@ class TestOptimizationInputFactory:
         bcc_handler = off_force_field.get_parameter_handler("ChargeIncrementModel")
         assert len(bcc_handler.parameters) == 1
         parameter = bcc_handler.parameters["[#6:1]-[#6:2]"]
+        assert len(parameter.charge_increment) == 1
         assert parameter._parameterize == "charge_increment1"
-        assert parameter._parameter_eval == (
-            "charge_increment2=-PRM['ChargeIncrementModel/ChargeIncrement/"
-            "charge_increment1/[#6:1]-[#6:2]']"
-        )
 
     def test_generate_force_balance_input(self, optimization):
 


### PR DESCRIPTION
## Description
This PR alters the optimisation input factory to no longer add `parameter_eval` statements when fitting BCC parameters.

This is no longer needed as the OpenFF toolkit >=0.8.0 will explicitly enforce the constraint that `charge_increment2` should be equal in magnitude but opposite in sign to `charge_increment1` if only `charge_increment1` is provided. 

The input factory ensures this constraint by making sure that the parameter attribute only ever provides `charge_increment1`.

## Status
- [X] Ready to go