### PR TITLE
Optional Evaluator Data Caching

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -30,7 +30,7 @@ dependencies:
     # Benchmark / optimization target dependencies
   - forcebalance >=1.7.5
   - openforcefield >=0.8.0
-  - openff-evaluator >=0.2.0
+  - openff-evaluator >=0.3.2
   - openff-recharge >=0.0.1a5
 
     # SMILES to SVG

--- a/nonbonded/cli/projects/benchmark/run.py
+++ b/nonbonded/cli/projects/benchmark/run.py
@@ -213,6 +213,9 @@ def run_command():
         # Load the server configuration.
         server_config = EvaluatorServerConfig.parse_file(kwargs.pop("server_config"))
 
+        if server_config.enable_data_caching is None:
+            server_config.enable_data_caching = False
+
         # Load in the request options
         request_options = RequestOptions.from_json(kwargs.pop("request_options"))
 

--- a/nonbonded/cli/projects/optimization/run.py
+++ b/nonbonded/cli/projects/optimization/run.py
@@ -143,6 +143,18 @@ def _launch_required_services(optimization: Optimization, server_config: Optiona
         )
 
     server_config = EvaluatorServerConfig.parse_file(server_config)
+
+    # Disable data caching when re-weighting is disabled and the user hasn't
+    # explicitly requested it.
+    requires_cached_data = any(
+        target.allow_reweighting
+        for target in optimization.targets
+        if isinstance(target, EvaluatorTarget)
+    )
+
+    if server_config.enable_data_caching is None:
+        server_config.enable_data_caching = requires_cached_data
+
     calculation_backend = server_config.to_backend()
 
     with calculation_backend:

--- a/nonbonded/library/factories/inputs/evaluator.py
+++ b/nonbonded/library/factories/inputs/evaluator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
@@ -144,6 +144,15 @@ class EvaluatorServerConfig(BaseModel):
         description="The directory in which to store any working files and directories",
     )
 
+    enable_data_caching: Optional[bool] = Field(
+        None,
+        description="Whether the server should attempt to cache any data, mainly the "
+        "output of simulations, produced by estimation requests for future "
+        "re-processing (e.g for reweighting).\n\n"
+        "If unspecified this value will be automatically set depending on the "
+        "properties to be estimated.",
+    )
+
     def to_backend(self):
         return self.backend_config.to_evaluator()
 
@@ -155,6 +164,7 @@ class EvaluatorServerConfig(BaseModel):
             calculation_backend=evaluator_backend,
             working_directory=self.working_directory,
             port=self.port,
+            enable_data_caching=self.enable_data_caching,
         )
 
         return evaluator_server


### PR DESCRIPTION
## Description
This PR makes caching of evaluator generated data optional depending on whether it is needed during an optimisation or whether the user explicitly requested it. 

## Status
- [X] Ready to go