### PR TITLE
Fix benchmark RMSD plot division by zero error

### DIFF
--- a/nonbonded/library/plotting/seaborn/benchmark.py
+++ b/nonbonded/library/plotting/seaborn/benchmark.py
@@ -220,7 +220,7 @@ def plot_categorized_rmse(
                         benchmark_plot_data["Lower CI"],
                         benchmark_plot_data["Upper CI"],
                     ],
-                    height=1.0 / (len(benchmarks) - 1),
+                    height=1.0 / max(len(benchmarks) - 1, 1),
                     label=benchmark.name,
                 )
 


### PR DESCRIPTION
## Description
This PR fixes a division by zero error when producing benchmark RMSD plots for only a single benchmark.

## Status
- [x] Ready to go