### PR TITLE
Fix optimization data re-indexing not triggered

### DIFF
--- a/nonbonded/library/factories/analysis/optimization.py
+++ b/nonbonded/library/factories/analysis/optimization.py
@@ -104,7 +104,7 @@ class OptimizationAnalysisFactory(AnalysisFactory):
 
                 target_analyzer_kwargs = {}
 
-                if isinstance(target_analyzer, EvaluatorAnalysisFactory):
+                if issubclass(target_analyzer, EvaluatorAnalysisFactory):
                     target_analyzer_kwargs["reindex"] = reindex
 
                 target_result = target_analyzer.analyze(


### PR DESCRIPTION
## Description
This PR fixes a bug whereby data re-indexing was never triggered due to incorrectly using `isinstance` rather than `issubclass`.

## Status
- [X] Ready to go