### PR TITLE
Update CI to use py=3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,8 @@ jobs:
     strategy:
 
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.8]
         os: [ubuntu-latest, macOS-latest]
-
-    env:
-      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

This PR updates the CI to use the earliest supported python version.

## Status
- [X] Ready to go