### PR TITLE
Fix #94

### DIFF
--- a/nonbonded/tests/library/factories/analysis/targets/test_evaluator.py
+++ b/nonbonded/tests/library/factories/analysis/targets/test_evaluator.py
@@ -1,9 +1,12 @@
+import logging
+import os.path
 from typing import Tuple
 
 import numpy
 import pytest
 from forcebalance.nifty import lp_dump
 from openff.evaluator.client import RequestResult
+from openff.evaluator.datasets import PhysicalPropertyDataSet
 
 from nonbonded.library.factories.analysis.targets.evaluator import (
     EvaluatorAnalysisFactory,
@@ -66,6 +69,40 @@ def test_analyze(mock_target):
         target_directory=directory,
         result_directory=directory,
         reindex=True,
+    )
+
+    assert numpy.isclose(target_result.objective_function, 1.0)
+    assert len(target_result.statistic_entries) == 1
+
+
+def test_analyze_non_integer_ids(mock_target, caplog):
+
+    optimization, target, directory = mock_target
+
+    reference_data_set: PhysicalPropertyDataSet = PhysicalPropertyDataSet.from_json(
+        os.path.join(directory, "training-set.json")
+    )
+    assert len(reference_data_set) == 1  # Sanity check in case this changes in future.
+    reference_data_set.properties[0].id = "a"
+    reference_data_set.json(os.path.join(directory, "training-set.json"))
+
+    results = RequestResult()
+    results.estimated_properties = reference_data_set
+    results.json(os.path.join(directory, "results.json"))
+
+    with caplog.at_level(logging.WARNING):
+
+        target_result = EvaluatorAnalysisFactory.analyze(
+            optimization=optimization,
+            target=target,
+            target_directory=directory,
+            result_directory=directory,
+            reindex=False,
+        )
+
+    assert (
+        "The reference data set contains properties "
+        "with ids that cannot be cast to integers" in caplog.text
     )
 
     assert numpy.isclose(target_result.objective_function, 1.0)


### PR DESCRIPTION
## Description

This PR fixes #94 by adding a warning and workaround for users that have set up their own optimisation directory but not used integer property ids for an evaluator target data set.

## Status
- [X] Ready to go