### PR TITLE
Add basic support for PBS and Slurm calculation backends

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install isort / flake8 / black
         run: |
-          pip install isort flake8 "black <22"
+          pip install isort flake8 "black=21.12b0"
 
       - name: Run isort
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install isort / flake8 / black
         run: |
-          pip install isort flake8 black
+          pip install isort flake8 "black <22"
 
       - name: Run isort
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install isort / flake8 / black
         run: |
-          pip install isort flake8 "black=21.12b0"
+          pip install isort flake8 "black==21.12b0"
 
       - name: Run isort
         run: |

--- a/nonbonded/library/factories/inputs/evaluator.py
+++ b/nonbonded/library/factories/inputs/evaluator.py
@@ -93,7 +93,7 @@ class DaskHPCClusterConfig(BaseModel):
     pbs_resource_line: Optional[str] = Field(
         None,
         description="The (optional) string to pass to the `#PBS -l` line in the worker "
-        "job script if using a PBS cluster."
+        "job script if using a PBS cluster.",
     )
 
     def to_evaluator(self) -> "dask.DaskLSFBackend":
@@ -120,7 +120,7 @@ class DaskHPCClusterConfig(BaseModel):
                 queue_name=self.queue_name,
                 setup_script_commands=self.setup_script_commands,
                 adaptive_interval="1000ms",
-                resource_line=self.pbs_resource_line
+                resource_line=self.pbs_resource_line,
             )
 
         elif self.cluster_type.lower() == "slurm":


### PR DESCRIPTION
## Description

This PR allows 'slurm' and 'pbs' cluster types to be used when specifying evaluator server configs.

## Status
- [X] Ready to go